### PR TITLE
feat: add assist discount sequence

### DIFF
--- a/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/ametller/pos/ncr/actions/init/AmetllerInitializeManager.java
+++ b/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/ametller/pos/ncr/actions/init/AmetllerInitializeManager.java
@@ -1,0 +1,61 @@
+package com.comerzzia.ametller.pos.ncr.actions.init;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.stereotype.Service;
+
+import com.comerzzia.pos.ncr.actions.init.InitializeManager;
+import com.comerzzia.pos.ncr.messages.BasicNCRMessage;
+import com.comerzzia.pos.ncr.messages.Command;
+import com.comerzzia.pos.ncr.messages.DataNeeded;
+import com.comerzzia.pos.ncr.messages.DataNeededReply;
+
+@Service
+@DependsOn("initializeManager")
+public class AmetllerInitializeManager extends InitializeManager {
+
+    private boolean waitingDiscountConfirmation = false;
+
+    @Override
+    public void processMessage(BasicNCRMessage message) {
+        if (message instanceof Command) {
+            Command command = (Command) message;
+            String cmd = command.getFieldValue(Command.Command);
+            if ("descuento".equalsIgnoreCase(cmd)) {
+                // A2
+                DataNeeded dataNeeded = new DataNeeded();
+                dataNeeded.setFieldValue(DataNeeded.Type, "1");
+                dataNeeded.setFieldValue(DataNeeded.Id, "2");
+                dataNeeded.setFieldValue(DataNeeded.Mode, "0");
+                dataNeeded.setFieldValue(DataNeeded.SummaryInstruction1, "Descuento 25% activado");
+                ncrController.sendMessage(dataNeeded);
+                waitingDiscountConfirmation = true;
+                return;
+            }
+        } else if (message instanceof DataNeededReply) {
+            DataNeededReply reply = (DataNeededReply) message;
+            String type = reply.getFieldValue(DataNeededReply.Type);
+            String id = reply.getFieldValue(DataNeededReply.Id);
+            if (waitingDiscountConfirmation && "1".equals(type) && "2".equals(id)) {
+                // A4
+                DataNeeded clean = new DataNeeded();
+                clean.setFieldValue(DataNeeded.Type, "0");
+                clean.setFieldValue(DataNeeded.Id, "0");
+                clean.setFieldValue(DataNeeded.Mode, "0");
+                ncrController.sendMessage(clean);
+                waitingDiscountConfirmation = false;
+                return;
+            }
+        }
+
+        super.processMessage(message);
+    }
+
+    @PostConstruct
+    @Override
+    public void init() {
+        super.init();
+        ncrController.registerActionManager(DataNeededReply.class, this);
+    }
+}

--- a/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/pos/ncr/messages/ExitAssistMode.java
+++ b/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/pos/ncr/messages/ExitAssistMode.java
@@ -1,0 +1,3 @@
+package com.comerzzia.pos.ncr.messages;
+
+public class ExitAssistMode extends BasicNCRMessage {}

--- a/comerzzia-ncr-pos-application/src/main/resources/i18n/messages_ca.properties
+++ b/comerzzia-ncr-pos-application/src/main/resources/i18n/messages_ca.properties
@@ -1,0 +1,1 @@
+assist.discount.button=Descompte 25%

--- a/comerzzia-ncr-pos-application/src/main/resources/i18n/messages_es.properties
+++ b/comerzzia-ncr-pos-application/src/main/resources/i18n/messages_es.properties
@@ -1,0 +1,1 @@
+assist.discount.button=Descuento 25%


### PR DESCRIPTION
## Summary
- handle "descuento" command through custom initialize manager
- support ExitAssistMode message
- remove temporary docs and tests

## Testing
- `mvn -q -pl comerzzia-ncr-pos-application -Dmaven.test.skip=false test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.4.3, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bac444af00832b8d08b5851210a5ae