### PR TITLE
feat: add configurable auto sign-on bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # NCR Self-Checkout integration with comerzzia POS
 
+
+## Auto Sign-On bypass
+
+The POS can force the login flow to continue even if the SCO does not send the `SignOn` message. This behaviour is configurable in `NCRPosConfiguration.xml`:
+
+```
+<forceAutoSignOn>true</forceAutoSignOn>
+<autoSignOnTimeoutMs>1200</autoSignOnTimeoutMs>
+<defaultUserIdWhenMissing>0</defaultUserIdWhenMissing>
+<defaultPasswordWhenMissing>1</defaultPasswordWhenMissing>
+<defaultRoleWhenMissing>Operator</defaultRoleWhenMissing>
+<defaultLaneNumber>27</defaultLaneNumber>
+<defaultMenuUid>MENU_POR_DEFECTO</defaultMenuUid>
+```
+
+Set `forceAutoSignOn` to `false` to disable the bypass.
+

--- a/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/pos/ncr/actions/init/AuthenticationManager.java
+++ b/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/pos/ncr/actions/init/AuthenticationManager.java
@@ -2,6 +2,11 @@ package com.comerzzia.pos.ncr.actions.init;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.annotation.PostConstruct;
 
@@ -16,6 +21,7 @@ import com.comerzzia.pos.ncr.actions.ActionManager;
 import com.comerzzia.pos.ncr.messages.BasicNCRMessage;
 import com.comerzzia.pos.ncr.messages.EnterTrainingMode;
 import com.comerzzia.pos.ncr.messages.ExitTrainingMode;
+import com.comerzzia.pos.ncr.messages.PosState;
 import com.comerzzia.pos.ncr.messages.SignOff;
 import com.comerzzia.pos.ncr.messages.SignOn;
 import com.comerzzia.pos.ncr.messages.TrainingModeEntered;
@@ -36,7 +42,7 @@ import com.comerzzia.pos.util.i18n.I18N;
 @Lazy(false)
 @Service
 public class AuthenticationManager implements ActionManager {
-	private static final Logger log = Logger.getLogger(AuthenticationManager.class);
+        private static final Logger log = Logger.getLogger(AuthenticationManager.class);
 
 	@Autowired
 	protected Sesion sesion;
@@ -50,19 +56,33 @@ public class AuthenticationManager implements ActionManager {
 	@Autowired
 	private ScoTillManager scotillManager;
 	
-	@Autowired
+        @Autowired
     protected ServicioPerfiles servicioPerfiles;
+
+       private final AtomicBoolean signOnArrived = new AtomicBoolean(false);
+       private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+       private ScheduledFuture<?> autoSignOnTask;
+       private String lastUserId;
+       private String lastPassword;
+       private String lastRole;
 
 	@Override
 	public void processMessage(BasicNCRMessage message) {
-		if (message instanceof ValidateUserId) {
-			validateUser((ValidateUserId)message);
-		} else if (message instanceof SignOn) {
-			SignOn response = new SignOn();
-
-			ncrController.sendMessage(response);
-		} else if (message instanceof SignOff) {
-			scotillManager.closeTill();
+               if (message instanceof ValidateUserId) {
+                        validateUser((ValidateUserId)message);
+                } else if (message instanceof SignOn) {
+                        signOnArrived.set(true);
+                        if (autoSignOnTask != null) {
+                                autoSignOnTask.cancel(false);
+                        }
+                        log.debug("[NCRController] 'SignOn' recibido del SCO dentro del timeout. Continuamos flujo estándar.");
+                        SignOn signOnMessage = (SignOn) message;
+                        proceedAfterSignOn(signOnMessage.getFieldValue(SignOn.UserId),
+                                        signOnMessage.getFieldValue(SignOn.Password),
+                                        signOnMessage.getFieldValue(SignOn.role),
+                                        signOnMessage.getFieldValue(SignOn.LaneNumber), false);
+                } else if (message instanceof SignOff) {
+                        scotillManager.closeTill();
 			
 			SignOff response = new SignOff();
 			response.setFieldValue(SignOff.LaneNumber, NCRPOSApplication.getSesion().getAplicacion().getCodCaja());
@@ -92,16 +112,22 @@ public class AuthenticationManager implements ActionManager {
 	}
 
 	public void validateUser(ValidateUserId message) {
-		ValidateUserId response = new ValidateUserId();
-		response.setFieldValue(ValidateUserId.UserId, message.getFieldValue(ValidateUserId.UserId));
+                ValidateUserId response = new ValidateUserId();
+                response.setFieldValue(ValidateUserId.UserId, message.getFieldValue(ValidateUserId.UserId));
 		
 		try {
-			if (ncrController.getConfiguration().isAuthenticationBypass() && AppConfig.modoDesarrollo) {
-				log.warn("Authentication bypass enabled. Ignoring user and password from message");
-				sesion.initUsuarioSesion(AppConfig.modoDesarrolloInfo.getUsuario(), AppConfig.modoDesarrolloInfo.getPassword());
-			} else {
-			    sesion.initUsuarioSesion(message.getFieldValue(ValidateUserId.UserId), message.getFieldValue(ValidateUserId.Password));
-			}   			
+                        if (ncrController.getConfiguration().isAuthenticationBypass() && AppConfig.modoDesarrollo) {
+                                log.warn("Authentication bypass enabled. Ignoring user and password from message");
+                                sesion.initUsuarioSesion(AppConfig.modoDesarrolloInfo.getUsuario(), AppConfig.modoDesarrolloInfo.getPassword());
+                                lastUserId = AppConfig.modoDesarrolloInfo.getUsuario();
+                                lastPassword = AppConfig.modoDesarrolloInfo.getPassword();
+                                lastRole = message.getFieldValue(ValidateUserId.role);
+                        } else {
+                                lastUserId = message.getFieldValue(ValidateUserId.UserId);
+                                lastPassword = message.getFieldValue(ValidateUserId.Password);
+                                lastRole = message.getFieldValue(ValidateUserId.role);
+                                sesion.initUsuarioSesion(lastUserId, lastPassword);
+                        }
 			
 			sesion.getSesionUsuario().clearPermisos();
 			
@@ -122,36 +148,79 @@ public class AuthenticationManager implements ActionManager {
 			response.setFieldValue(ValidateUserId.Message, ex.getMessage());			
 		}		
 
-		ncrController.sendMessage(response);
-	}
+                ncrController.sendMessage(response);
+
+               if (ncrController.getConfiguration().isForceAutoSignOn()) {
+                       log.debug("[NCRController] ValidateUserId enviado (AuthenticationLevel=2). Esperando 'SignOn' del SCO hasta "
+                                       + ncrController.getConfiguration().getAutoSignOnTimeoutMs() + " ms...");
+                       signOnArrived.set(false);
+                       autoSignOnTask = scheduler.schedule(() -> {
+                               if (!signOnArrived.get()) {
+                                       log.warn("[NCRController] AutoSignOn: no se recibió 'SignOn' del SCO en "
+                                                       + ncrController.getConfiguration().getAutoSignOnTimeoutMs()
+                                                       + " ms; forzamos flujo de sign-on (config=forceAutoSignOn=true).");
+
+                                       String effUser = (lastUserId != null && !lastUserId.isEmpty()) ? lastUserId
+                                                       : ncrController.getConfiguration().getDefaultUserIdWhenMissing();
+                                       String effPass = (lastPassword != null && !lastPassword.isEmpty()) ? lastPassword
+                                                       : ncrController.getConfiguration().getDefaultPasswordWhenMissing();
+                                       String effRole = (lastRole != null && !lastRole.isEmpty()) ? lastRole
+                                                       : ncrController.getConfiguration().getDefaultRoleWhenMissing();
+                                       proceedAfterSignOn(effUser, effPass, effRole,
+                                                       ncrController.getConfiguration().getDefaultLaneNumber(), true);
+                               }
+                       }, ncrController.getConfiguration().getAutoSignOnTimeoutMs(), TimeUnit.MILLISECONDS);
+               }
+        }
 	
-	@SuppressWarnings("unchecked")
-	protected String getAuthenticationLevel(Long userId) {
-		ParametrosBuscarPerfilesBean param = new ParametrosBuscarPerfilesBean();
-		param.setTamañoPagina(Integer.MAX_VALUE);
-		param.setNumPagina(1);
-		param.setIdUsuario(userId);
-		
-		boolean isSuperAdminUser = false;
-		boolean isHeadCashierRole = false;
-		final Set<Long> headCashierRoles = ncrController.getConfiguration().getHeadCashierRoles();
-		
-		try {
-			List<PerfilBean> perfiles = (List<PerfilBean>) servicioPerfiles.consultar(param).getPagina();
-			for (PerfilBean perfilBean : perfiles) {
-				if (perfilBean.getIdPerfil().equals(0l)) {
-					isSuperAdminUser = true;
-				}
-				
-				if (headCashierRoles.contains(perfilBean.getIdPerfil())) {
-					isHeadCashierRole = true;
-				}
-			}
-		} catch (PerfilException e) {
-			log.error("Error loading user roles: " + e.getMessage());
-		}
-		
-		
-		return (isSuperAdminUser || isHeadCashierRole ? ValidateUserId.AUTH_LEVEL_HEAD_CASHIER : ValidateUserId.AUTH_LEVEL_CASHIER);
-	}
+        @SuppressWarnings("unchecked")
+        protected String getAuthenticationLevel(Long userId) {
+                ParametrosBuscarPerfilesBean param = new ParametrosBuscarPerfilesBean();
+                param.setTamañoPagina(Integer.MAX_VALUE);
+                param.setNumPagina(1);
+                param.setIdUsuario(userId);
+
+                boolean isSuperAdminUser = false;
+                boolean isHeadCashierRole = false;
+                final Set<Long> headCashierRoles = ncrController.getConfiguration().getHeadCashierRoles();
+
+                try {
+                        List<PerfilBean> perfiles = (List<PerfilBean>) servicioPerfiles.consultar(param).getPagina();
+                        for (PerfilBean perfilBean : perfiles) {
+                                if (perfilBean.getIdPerfil().equals(0l)) {
+                                        isSuperAdminUser = true;
+                                }
+
+                                if (headCashierRoles.contains(perfilBean.getIdPerfil())) {
+                                        isHeadCashierRole = true;
+                                }
+                        }
+                } catch (PerfilException e) {
+                        log.error("Error loading user roles: " + e.getMessage());
+                }
+
+                return (isSuperAdminUser || isHeadCashierRole ? ValidateUserId.AUTH_LEVEL_HEAD_CASHIER : ValidateUserId.AUTH_LEVEL_CASHIER);
+        }
+
+        private void proceedAfterSignOn(String userId, String password, String role, String lane, boolean fromAuto) {
+                try {
+                        sesion.initUsuarioSesion(userId, password);
+                } catch (Exception e) {
+                        log.error("Error initializing session: " + e.getMessage(), e);
+                }
+
+                if (fromAuto && ncrController.getConfiguration().isForceAutoSignOn()) {
+                        log.warn("[LoginFlowGuard] Fallback de perfil/menú aplicado (forceAutoSignOn).");
+                }
+
+                PosState posState = new PosState();
+                posState.setFieldValue(PosState.State, "active");
+                ncrController.sendMessage(posState);
+
+                SignOn response = new SignOn();
+                ncrController.sendMessage(response);
+
+                log.info("[NCRController] Login/ventas habilitado" + (fromAuto ? " (AUTO)" : "")
+                                + " para userId='" + userId + "', lane='" + lane + "'.");
+        }
 }

--- a/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/pos/ncr/configuration/NCRPosConfiguration.java
+++ b/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/pos/ncr/configuration/NCRPosConfiguration.java
@@ -20,6 +20,14 @@ public class NCRPosConfiguration {
    protected boolean authenticationBypass = false;
    protected boolean sendLinesDiscounts = true;
    protected boolean simulateAllPayAsCash = false;
+
+   protected boolean forceAutoSignOn = false;
+   protected long autoSignOnTimeoutMs = 1200L;
+   protected String defaultUserIdWhenMissing = "0";
+   protected String defaultPasswordWhenMissing = "1";
+   protected String defaultRoleWhenMissing = "Operator";
+   protected String defaultLaneNumber = "1";
+   protected String defaultMenuUid = "MENU_POR_DEFECTO";
       
    @XmlJavaTypeAdapter(MapAdapter.class)
    protected Map<String, String> paymentsCodesMapping = new HashMap<String, String>();
@@ -66,9 +74,65 @@ public class NCRPosConfiguration {
 		return simulateAllPayAsCash;
 	}
 
-	public void setSimulateAllPayAsCash(boolean simulateAllPayAsCash) {
-		this.simulateAllPayAsCash = simulateAllPayAsCash;
-	}
+        public void setSimulateAllPayAsCash(boolean simulateAllPayAsCash) {
+                this.simulateAllPayAsCash = simulateAllPayAsCash;
+        }
+
+       public boolean isForceAutoSignOn() {
+               return forceAutoSignOn;
+       }
+
+       public void setForceAutoSignOn(boolean forceAutoSignOn) {
+               this.forceAutoSignOn = forceAutoSignOn;
+       }
+
+       public long getAutoSignOnTimeoutMs() {
+               return autoSignOnTimeoutMs;
+       }
+
+       public void setAutoSignOnTimeoutMs(long autoSignOnTimeoutMs) {
+               this.autoSignOnTimeoutMs = autoSignOnTimeoutMs;
+       }
+
+       public String getDefaultUserIdWhenMissing() {
+               return defaultUserIdWhenMissing;
+       }
+
+       public void setDefaultUserIdWhenMissing(String defaultUserIdWhenMissing) {
+               this.defaultUserIdWhenMissing = defaultUserIdWhenMissing;
+       }
+
+       public String getDefaultPasswordWhenMissing() {
+               return defaultPasswordWhenMissing;
+       }
+
+       public void setDefaultPasswordWhenMissing(String defaultPasswordWhenMissing) {
+               this.defaultPasswordWhenMissing = defaultPasswordWhenMissing;
+       }
+
+       public String getDefaultRoleWhenMissing() {
+               return defaultRoleWhenMissing;
+       }
+
+       public void setDefaultRoleWhenMissing(String defaultRoleWhenMissing) {
+               this.defaultRoleWhenMissing = defaultRoleWhenMissing;
+       }
+
+       public String getDefaultLaneNumber() {
+               return defaultLaneNumber;
+       }
+
+       public void setDefaultLaneNumber(String defaultLaneNumber) {
+               this.defaultLaneNumber = defaultLaneNumber;
+       }
+
+       public String getDefaultMenuUid() {
+               return defaultMenuUid;
+       }
+
+       public void setDefaultMenuUid(String defaultMenuUid) {
+               this.defaultMenuUid = defaultMenuUid;
+       }
 
 	public Map<String, String> getPaymentsCodesMapping() {
 		return paymentsCodesMapping;

--- a/comerzzia-ncr-pos-application/src/main/resources/NCRPosConfiguration.xml
+++ b/comerzzia-ncr-pos-application/src/main/resources/NCRPosConfiguration.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ncrPosConfiguration>
+    <forceAutoSignOn>true</forceAutoSignOn>
+    <autoSignOnTimeoutMs>1200</autoSignOnTimeoutMs>
+    <defaultUserIdWhenMissing>0</defaultUserIdWhenMissing>
+    <defaultPasswordWhenMissing>1</defaultPasswordWhenMissing>
+    <defaultRoleWhenMissing>Operator</defaultRoleWhenMissing>
+    <defaultLaneNumber>27</defaultLaneNumber>
+    <defaultMenuUid>MENU_POR_DEFECTO</defaultMenuUid>
+</ncrPosConfiguration>


### PR DESCRIPTION
## Summary
- add optional auto SignOn flow with timeout to recover frozen SCO sessions
- extend NCR configuration with auto sign-on parameters
- document auto sign-on bypass configuration

## Testing
- `mvn -q -e package` *(fails: Plugin not found in any plugin repository)*

------
https://chatgpt.com/codex/tasks/task_e_68bffe1997bc832bacf9516e144598b9