### PR TITLE
fix: update CI and repository settings

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,36 +6,36 @@ image: maven:3.6-jdk-8-slim
 
 variables:
   GIT_SUBMODULE_STRATEGY: normal
-  MAVEN_OPTS: "-Djava.awt.headless=true -Dmaven.repo.local=.m2/repository"  
-  MAVEN_CLI_OPTS: "-s .m2/settings.xml -DaltReleaseDeploymentRepository=comerzzia::default::http://artifactory.tier1.es/artifactory/comerzzia-releases.local -DaltSnapshotDeploymentRepository=comerzzia::default::http://artifactory.tier1.es/artifactory/comerzzia-snapshots.local --batch-mode --errors --fail-at-end --show-version -s .m2/settings.xml"
+  MAVEN_OPTS: "-Djava.awt.headless=true -Dmaven.repo.local=.m2/repository"
+  MAVEN_CLI_OPTS: "-s .m2/settings.xml -DaltReleaseDeploymentRepository=comerzzia::default::http://artifactory.tier1.es/artifactory/comerzzia-releases.local -DaltSnapshotDeploymentRepository=comerzzia::default::http://artifactory.tier1.es/artifactory/comerzzia-snapshots.local --batch-mode --errors --fail-at-end --show-version"
   
 cache:
   key: ${CI_COMMIT_REF_SLUG}
   paths:
   - .m2/repository
   
-build:maven:
+build_maven:
   stage: build
   only:
-  - master
-  - /^support/.*$/
-  - /^release/.*$/
+    - develop
+    - branches
   script:
-  - mvn $MAVEN_CLI_OPTS package -DskipTests
+    - mvn $MAVEN_CLI_OPTS deploy -DskipTests
   artifacts:
     paths:
     - comerzzia-ncr-pos-application/target/*.jar
     expire_in: 1 hour
 
 
-build_release:
+release_tag:
   stage: release
   only:
-  - tags
+    - tags
   script:
-  - mvn $MAVEN_CLI_OPTS versions:set -DnewVersion=$CI_COMMIT_TAG
-  - mvn $MAVEN_CLI_OPTS deploy -DskipTests
+    - echo "Versión del tag $CI_COMMIT_TAG"
+    - mvn $MAVEN_CLI_OPTS versions:set -DnewVersion=$CI_COMMIT_TAG
+    - mvn $MAVEN_CLI_OPTS deploy -DskipTests
   artifacts:
     paths:
-    - comerzzia-ncr-pos-application/target/*.jar
+      - comerzzia-ncr-pos-application/target/*.jar
     expire_in: 1 day

--- a/.m2/settings.xml
+++ b/.m2/settings.xml
@@ -1,40 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">  
-	<profiles>
-		<profile>
-			<id>comerzzia</id>
-			<repositories>
-				<repository> 
-					<id>comerzzia</id> 
-					<name>Comerzzia artifactory</name> 
-					<url>https://repo.comerzzia.com/artifactory/comerzzia/</url>
-					<snapshots>
-						<enabled>true</enabled>
-						<updatePolicy>always</updatePolicy>
-					</snapshots>
-				</repository> 			
-			</repositories>
-			<pluginRepositories>
-				<pluginRepository>
-					<id>comerzzia</id> 
-					<name>Comerzzia artifactory</name> 
-					<url>https://repo.comerzzia.com/artifactory/comerzzia/</url>
-				</pluginRepository>
-			</pluginRepositories>
-		</profile>
-	</profiles>
+        <profiles>
+                <profile>
+                        <id>artifactory</id>
+                        <repositories>
+                                <repository>
+                                        <id>comerzzia</id>
+                                        <name>Comerzzia artifactory</name>
+                                        <url>http://artifactory.tier1.es/artifactory/comerzzia/</url>
+                                        <snapshots>
+                                                <enabled>true</enabled>
+                                                <updatePolicy>always</updatePolicy>
+                                        </snapshots>
+                                </repository>
+                                <repository>
+                                        <snapshots>
+                                                <enabled>true</enabled>
+                                                <updatePolicy>always</updatePolicy>
+                                        </snapshots>
+                                        <id>central</id>
+                                        <name>software.mpsistemas.virtual</name>
+                                        <url>https://repomaven.tier1.es/artifactory/tier1/</url>
+                                </repository>
+                        </repositories>
+                        <pluginRepositories>
+                                <pluginRepository>
+                                        <id>comerzzia</id>
+                                        <name>Comerzzia artifactory</name>
+                                        <url>http://artifactory.tier1.es/artifactory/comerzzia/</url>
+                                </pluginRepository>
+                        </pluginRepositories>
+                </profile>
+        </profiles>
 
-	<activeProfiles>
-		<activeProfile>comerzzia</activeProfile>
-	</activeProfiles>
+        <activeProfiles>
+                <activeProfile>artifactory</activeProfile>
+        </activeProfiles>
 
-	<servers>
-		<!-- artifactory credentials -->
-		<server>
-			<id>comerzzia</id>
-			<username>${env.MAVEN_REPO_USER}</username>
-			<password>${env.MAVEN_REPO_PASS}</password>		   
-		</server>
-	</servers>
+        <servers>
+                <!-- artifactory credentials -->
+                <server>
+                        <id>comerzzia</id>
+                        <username>${env.MAVEN_REPO_USER}</username>
+                        <password>${env.MAVEN_REPO_PASS}</password>
+                </server>
+                <server>
+                        <id>clientes</id>
+                        <username>${env.MAVEN_REPO_USER}</username>
+                        <password>${env.MAVEN_REPO_PASS}</password>
+                </server>
+                <server>
+                        <id>central</id>
+                        <username>${env.MAVEN_REPO_USER}</username>
+                        <password>${env.MAVEN_REPO_PASS}</password>
+                </server>
+        </servers>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -18,19 +18,19 @@
 		<java.version>1.8</java.version>
 	</properties>
 	
-	<repositories>
-		<repository>
-			<id>comerzzia</id>
-			<url>https://repo.comerzzia.com/artifactory/comerzzia/</url>
-		</repository>
-	</repositories>
+        <repositories>
+                <repository>
+                        <id>comerzzia</id>
+                        <url>http://artifactory.tier1.es/artifactory/comerzzia/</url>
+                </repository>
+        </repositories>
 
-	<pluginRepositories>
-		<pluginRepository>
-			<id>comerzzia</id>
-			<url>https://repo.comerzzia.com/artifactory/comerzzia/</url>
-		</pluginRepository>
-	</pluginRepositories>
+        <pluginRepositories>
+                <pluginRepository>
+                        <id>comerzzia</id>
+                        <url>http://artifactory.tier1.es/artifactory/comerzzia/</url>
+                </pluginRepository>
+        </pluginRepositories>
 	
 	<modules>
 		<module>comerzzia-ncr-pos-application</module>


### PR DESCRIPTION
## Summary
- refresh GitLab CI to deploy artifacts from branches and tags
- point Maven settings to tier1 artifactory and include central mirror
- switch parent POM repositories to tier1 artifactory host

## Testing
- `mvn -q package -DskipTests` *(fails: Error resolving version for plugin 'org.apache.maven.plugins:maven-compiler-plugin' due to blocked HTTP)*

------
https://chatgpt.com/codex/tasks/task_e_68c0488f656c832bb4bd5da595b37c4b