### PR TITLE
chore(ci): build jars without deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ build_maven:
     - develop
     - branches
   script:
-    - mvn $MAVEN_CLI_OPTS deploy -DskipTests
+    - mvn $MAVEN_CLI_OPTS clean package -DskipTests
   artifacts:
     paths:
     - comerzzia-ncr-pos-application/target/*.jar


### PR DESCRIPTION
## Summary
- build jars in CI without deploying to Artifactory

## Testing
- `mvn -s .m2/settings.xml package -DskipTests` *(fails: Plugin not found in any plugin repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c04b028c88832b9951dda596d46abe