### PR TITLE
Handle NCR discount command with custom managers

### DIFF
--- a/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/ametller/pos/gui/ventas/tickets/AmetllerTicketManager.java
+++ b/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/ametller/pos/gui/ventas/tickets/AmetllerTicketManager.java
@@ -1,0 +1,62 @@
+package com.comerzzia.ametller.pos.gui.ventas.tickets;
+
+import java.math.BigDecimal;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.comerzzia.pos.gui.ventas.tickets.TicketManager;
+import com.comerzzia.pos.services.ticket.lineas.LineaTicket;
+import com.comerzzia.pos.services.ticket.lineas.LineaTicketException;
+
+import javafx.stage.Stage;
+
+/**
+ * Custom ticket manager that applies a 25% manual discount to every new line
+ * when the discount mode is active. It extends the standard {@link TicketManager}
+ * used by the POS.
+ */
+@Component
+@Scope("prototype")
+@Primary
+public class AmetllerTicketManager extends TicketManager {
+
+    private static final BigDecimal DESCUENTO25 = new BigDecimal("25.00");
+
+    private boolean descuento25Activo = false;
+
+    /**
+     * Toggles the 25% discount mode. Intended for use by the GUI button.
+     */
+    public boolean toggleDescuento25() {
+        descuento25Activo = !descuento25Activo;
+        return descuento25Activo;
+    }
+
+    /**
+     * Explicit setter used by the NCR messaging to control the flag.
+     */
+    public void setDescuento25Activo(boolean activo) {
+        this.descuento25Activo = activo;
+    }
+
+    /**
+     * Indicates whether the discount mode is active.
+     */
+    public boolean isDescuento25Activo() {
+        return descuento25Activo;
+    }
+
+    @Override
+    public synchronized LineaTicket nuevaLineaArticulo(String codArticulo, String desglose1, String desglose2,
+            BigDecimal cantidad, Stage stage, Integer idLineaDocOrigen, boolean esLineaDevolucionPositiva,
+            boolean applyDUN14Factor) throws LineaTicketException {
+        LineaTicket linea = super.nuevaLineaArticulo(codArticulo, desglose1, desglose2, cantidad, stage,
+                idLineaDocOrigen, esLineaDevolucionPositiva, applyDUN14Factor);
+        if (descuento25Activo && linea != null) {
+            linea.setDescuentoManual(DESCUENTO25);
+        }
+        return linea;
+    }
+}

--- a/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/ametller/pos/ncr/actions/AmetllerCommandManager.java
+++ b/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/ametller/pos/ncr/actions/AmetllerCommandManager.java
@@ -1,0 +1,87 @@
+package com.comerzzia.ametller.pos.ncr.actions;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+import com.comerzzia.pos.ncr.NCRController;
+import com.comerzzia.pos.ncr.actions.ActionManager;
+import com.comerzzia.pos.ncr.messages.BasicNCRMessage;
+import com.comerzzia.pos.ncr.messages.Command;
+import com.comerzzia.pos.ncr.messages.DataNeeded;
+import com.comerzzia.pos.ncr.messages.DataNeededReply;
+import com.comerzzia.pos.ncr.ticket.ScoTicketManager;
+import com.comerzzia.ametller.pos.ncr.ticket.AmetllerScoTicketManager;
+
+@Lazy(false)
+@Service
+public class AmetllerCommandManager implements ActionManager {
+
+    private static final Logger log = Logger.getLogger(AmetllerCommandManager.class);
+
+    @Autowired
+    private NCRController ncrController;
+
+    @Autowired
+    private ScoTicketManager ticketManager;
+
+    @Override
+    public void processMessage(BasicNCRMessage message) {
+        if (message instanceof Command) {
+            String cmd = message.getFieldValue(Command.Command);
+            if (cmd != null && cmd.equalsIgnoreCase("Descuento")) {
+                activarDescuento25();
+                enviarDataNeeded25();
+            } else if ("EnteredCustomerMode".equalsIgnoreCase(cmd)) {
+                desactivarDescuento25();
+            }
+        } else if (message instanceof DataNeededReply) {
+            String type = message.getFieldValue(DataNeededReply.Type);
+            String id = message.getFieldValue(DataNeededReply.Id);
+            if ("1".equals(type) && "2".equals(id)) {
+                DataNeeded clear = new DataNeeded();
+                clear.setFieldValue(DataNeeded.Type, "0");
+                clear.setFieldValue(DataNeeded.Id, "0");
+                clear.setFieldValue(DataNeeded.Mode, "0");
+                ncrController.sendMessage(clear);
+            }
+        } else {
+            log.warn("Message type not managed: " + message.getName());
+        }
+    }
+
+    private void activarDescuento25() {
+        if (ticketManager instanceof AmetllerScoTicketManager) {
+            ((AmetllerScoTicketManager) ticketManager).setDescuento25Activo(true);
+        } else {
+            log.warn("ScoTicketManager is not instance of AmetllerScoTicketManager");
+        }
+    }
+
+    private void desactivarDescuento25() {
+        if (ticketManager instanceof AmetllerScoTicketManager) {
+            ((AmetllerScoTicketManager) ticketManager).setDescuento25Activo(false);
+        }
+    }
+
+    private void enviarDataNeeded25() {
+        DataNeeded dn = new DataNeeded();
+        dn.setFieldValue(DataNeeded.Type, "1");
+        dn.setFieldValue(DataNeeded.Id, "2");
+        dn.setFieldValue(DataNeeded.Mode, "0");
+        dn.setFieldValue(DataNeeded.SummaryInstruction1,
+                "Descuento 25% ACTIVADO.\n" +
+                "Escanee los artículos con fecha próxima de caducidad.\n" +
+                "Pulse OK para continuar.");
+        ncrController.sendMessage(dn);
+    }
+
+    @PostConstruct
+    public void init() {
+        ncrController.registerActionManager(Command.class, this);
+        ncrController.registerActionManager(DataNeededReply.class, this);
+    }
+}

--- a/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
+++ b/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
@@ -1,0 +1,20 @@
+package com.comerzzia.ametller.pos.ncr.actions.sale;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import com.comerzzia.ametller.pos.ncr.ticket.AmetllerScoTicketManager;
+import com.comerzzia.pos.ncr.actions.sale.PayManager;
+
+@Service
+@Primary
+public class AmetllerPayManager extends PayManager {
+
+    @Override
+    protected void activateTenderMode() {
+        if (ticketManager instanceof AmetllerScoTicketManager) {
+            ((AmetllerScoTicketManager) ticketManager).setDescuento25Activo(false);
+        }
+        super.activateTenderMode();
+    }
+}

--- a/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/ametller/pos/ncr/ticket/AmetllerScoTicketManager.java
+++ b/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/ametller/pos/ncr/ticket/AmetllerScoTicketManager.java
@@ -1,0 +1,32 @@
+package com.comerzzia.ametller.pos.ncr.ticket;
+
+import java.math.BigDecimal;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import com.comerzzia.pos.ncr.ticket.ScoTicketManager;
+import com.comerzzia.pos.services.ticket.lineas.LineaTicket;
+import com.comerzzia.pos.services.ticket.lineas.LineaTicketAbstract;
+
+@Service
+@Primary
+public class AmetllerScoTicketManager extends ScoTicketManager {
+
+    private static final BigDecimal DESCUENTO25 = new BigDecimal("25.00");
+    private boolean descuento25Activo = false;
+
+    public void setDescuento25Activo(boolean activo) {
+        this.descuento25Activo = activo;
+    }
+
+    @Override
+    public LineaTicket addLineToTicket(LineaTicketAbstract linea) {
+        LineaTicket added = super.addLineToTicket(linea);
+        if (descuento25Activo && added != null) {
+            added.setDescuentoManual(DESCUENTO25);
+            recalculateTicket();
+        }
+        return added;
+    }
+}

--- a/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/pos/ncr/messages/ExitAssistMode.java
+++ b/comerzzia-ncr-pos-application/src/main/java/com/comerzzia/pos/ncr/messages/ExitAssistMode.java
@@ -1,0 +1,10 @@
+package com.comerzzia.pos.ncr.messages;
+
+/**
+ * Placeholder message used to acknowledge the NCR {@code ExitAssistMode}
+ * command so the message factory can create an instance without throwing a
+ * {@code Message class not found} error.
+ */
+public class ExitAssistMode extends BasicNCRMessage {
+    // no fields required
+}


### PR DESCRIPTION
## Summary
- Provide AmetllerTicketManager with explicit discount flag setter
- Add custom NCR managers to activate 25% discount and clear popup via DataNeeded
- Ensure discount mode ends on tender mode and support ExitAssistMode message

## Testing
- `mvn -q -e -Dmaven.test.skip=false test` *(fails: Non-resolvable parent POM com.comerzzia.integrations.selfcheckout.ncr:comerzzia-ncr-ssco-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68c172751664832b8042b0ea1f1c17e7