### PR TITLE
Handle gift card balance without setSaldoTotal

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
@@ -57,14 +57,24 @@ public class AmetllerPayManager extends PayManager {
             RedeemResponse redeem = giftCardProvider.redeem(barcode, apply,
                     String.valueOf(ticketManager.getTicket().getIdTicket()));
 
+            BigDecimal approvedAmount = redeem.getApprovedAmount();
+            if (approvedAmount == null) {
+                approvedAmount = BigDecimal.ZERO;
+            }
+            BigDecimal remainingBalance = redeem.getRemainingBalance();
+            if (remainingBalance == null) {
+                remainingBalance = BigDecimal.ZERO;
+            }
+
             GiftCardBean card = new GiftCardBean();
             card.setNumTarjetaRegalo(barcode);
-            card.setSaldoTotal(balance);
-            card.setSaldo(balance);
-            card.setSaldoProvisional(redeem.getRemainingBalance());
+            card.setSaldo(remainingBalance);
+            card.setSaldoProvisional(approvedAmount);
+            card.setImportePago(approvedAmount);
+            card.setUidTransaccion(redeem.getTransactionId());
             manager.addParameter(GiftCardManager.PARAM_TARJETA, card);
 
-            paymentsManager.pay(paymentCode, redeem.getApprovedAmount());
+            paymentsManager.pay(paymentCode, approvedAmount);
         } catch (GiftCardException e) {
             TenderException ex = new TenderException();
             ex.setFieldValue(TenderException.ExceptionId, "0");


### PR DESCRIPTION
## Summary
- populate `GiftCardBean` during gift card payments using existing setters
- guard against null approved/remaining amounts and include transaction id before delegating payment

## Testing
- mvn test *(fails: Maven cannot download plugins in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68c954344344832bbad32c19714aeb80