### PR TITLE
Implement gift card tender flow

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/AmetllerCommandManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/AmetllerCommandManager.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import com.comerzzia.pos.ncr.NCRController;
 import com.comerzzia.pos.ncr.actions.ActionManager;
+import com.comerzzia.pos.ncr.actions.sale.PayManager;
 import com.comerzzia.pos.ncr.messages.BasicNCRMessage;
 import com.comerzzia.pos.ncr.messages.Command;
 import com.comerzzia.pos.ncr.messages.DataNeeded;
@@ -28,6 +29,9 @@ public class AmetllerCommandManager implements ActionManager {
     @Autowired
     private ScoTicketManager ticketManager;
 
+    @Autowired
+    private PayManager payManager;
+
     @Override
     public void processMessage(BasicNCRMessage message) {
         if (message instanceof Command) {
@@ -39,6 +43,10 @@ public class AmetllerCommandManager implements ActionManager {
                 desactivarDescuento25();
             }
         } else if (message instanceof DataNeededReply) {
+            if (payManager != null && payManager.handleDataNeededReply((DataNeededReply) message)) {
+                return;
+            }
+
             String type = message.getFieldValue(DataNeededReply.Type);
             String id = message.getFieldValue(DataNeededReply.Id);
             if ("1".equals(type) && "2".equals(id)) {

--- a/src/main/java/com/comerzzia/pos/ncr/actions/sale/PayManager.java
+++ b/src/main/java/com/comerzzia/pos/ncr/actions/sale/PayManager.java
@@ -1,7 +1,12 @@
 package com.comerzzia.pos.ncr.actions.sale;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,12 +19,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
+import com.comerzzia.core.servicios.ContextHolder;
 import com.comerzzia.pos.core.dispositivos.Dispositivos;
 import com.comerzzia.pos.core.dispositivos.dispositivo.impresora.IPrinter;
 import com.comerzzia.pos.ncr.NCRController;
 import com.comerzzia.pos.ncr.actions.ActionManager;
 import com.comerzzia.pos.ncr.devices.printer.NCRSCOPrinter;
 import com.comerzzia.pos.ncr.messages.BasicNCRMessage;
+import com.comerzzia.pos.ncr.messages.DataNeeded;
+import com.comerzzia.pos.ncr.messages.DataNeededReply;
 import com.comerzzia.pos.ncr.messages.EndTransaction;
 import com.comerzzia.pos.ncr.messages.EnterTenderMode;
 import com.comerzzia.pos.ncr.messages.ExitTenderMode;
@@ -52,12 +60,31 @@ import com.comerzzia.pos.util.bigdecimal.BigDecimalUtil;
 @Lazy(false)
 @Service
 public class PayManager implements ActionManager {
-	private static final Logger log = Logger.getLogger(PayManager.class);
+        private static final Logger log = Logger.getLogger(PayManager.class);
 
-	protected boolean eventsRegistered = false;
-	
-	@Autowired
-	protected NCRController ncrController;
+        protected static final String OTHER_CARDS_TENDER_TYPE = "Otras Tarjetas";
+        protected static final String DIALOG_CONFIRM_TYPE = "4";
+        protected static final String DIALOG_CONFIRM_ID = "1";
+        protected static final String DEFAULT_GIFT_CARD_PARAMETER = "PARAM_NUMERO_TARJETA";
+        protected static final String DEFAULT_GIFT_CARD_PARAMETER_ALTERNATIVE = "PARAM_TARJETA";
+        protected static final String[] PREFIJOS_TARJETAS_BEAN_NAMES = {
+                        "prefijosTarjetasService",
+                        "prefijosTarjetasSrv"
+        };
+        protected static final String[] PREFIJOS_TARJETAS_CLASS_NAMES = {
+                        "com.comerzzia.pos.services.mediospagos.PrefijosTarjetasService",
+                        "com.comerzzia.pos.services.mediospagos.prefijos.PrefijosTarjetasService",
+                        "com.comerzzia.pos.services.payments.PrefijosTarjetasService",
+                        "com.comerzzia.pos.services.payments.methods.PrefijosTarjetasService",
+                        "com.comerzzia.pos.services.payments.methods.types.PrefijosTarjetasService"
+        };
+
+        protected boolean eventsRegistered = false;
+
+        protected PendingPaymentRequest pendingPayment;
+
+        @Autowired
+        protected NCRController ncrController;
 
 	@Autowired
 	protected ItemsManager itemsManager;
@@ -199,48 +226,487 @@ public class PayManager implements ActionManager {
 		return scoCode;
 	}
 	
-	protected void trayPay(Tender message) {
-		if (ticketManager.isTrainingMode()) {
-			// Automatic pay accepted message for training mode
-			TenderAccepted response = new TenderAccepted();
-			response.setFieldValue(TenderAccepted.Amount, message.getFieldValue(Tender.Amount));
-			response.setFieldValue(TenderAccepted.TenderType, message.getFieldValue(Tender.TenderType));
-			response.setFieldValue(TenderAccepted.Description, message.getFieldValue(Tender.TenderType));
-			
-			return;
-		}
-		
-		PaymentsManager paymentsManager = ticketManager.getPaymentsManager();
-		
-		BigDecimal importe = new BigDecimal(message.getFieldValue(Tender.Amount)).divide(new BigDecimal(100));
+        protected void trayPay(Tender message) {
+                if (ticketManager.isTrainingMode()) {
+                        // Automatic pay accepted message for training mode
+                        TenderAccepted response = new TenderAccepted();
+                        response.setFieldValue(TenderAccepted.Amount, message.getFieldValue(Tender.Amount));
+                        response.setFieldValue(TenderAccepted.TenderType, message.getFieldValue(Tender.TenderType));
+                        response.setFieldValue(TenderAccepted.Description, message.getFieldValue(Tender.TenderType));
 
-		try {
-		   if (StringUtils.equalsIgnoreCase("Credit", message.getFieldValue(Tender.TenderType))) {
-			    // this message force the SCO to wait TenderAccepted or TenderException message
-			    TenderException response = new TenderException();
-			    response.setFieldValue(TenderException.TenderType, message.getFieldValue(Tender.TenderType));
-			    response.setFieldValue(TenderException.ExceptionType, "0");
-			    response.setFieldValue(TenderException.ExceptionId, "1");			    
-			    ncrController.sendMessage(response);
-		   }
-		   
-		   paymentsManager.pay(scoTenderTypeToComerzziaPaymentCode(message.getFieldValue(Tender.TenderType)), importe);
-		} catch (Exception e) {
-			if (e instanceof PaymentException) {
-				PaymentErrorEvent errorEvent = new PaymentErrorEvent(this, ((PaymentException)e).getPaymentId(), e, ((PaymentException)e).getErrorCode(), ((PaymentException)e).getMessage());
-				PaymentsErrorEvent event = new PaymentsErrorEvent(this, errorEvent);
-				paymentsManager.getEventsHandler().paymentsError(event);						
-				
-			} else {
-				PaymentErrorEvent errorEvent = new PaymentErrorEvent(this, -1, e, null, null);
-				PaymentsErrorEvent event = new PaymentsErrorEvent(this, errorEvent);
-				paymentsManager.getEventsHandler().paymentsError(event);						
-			}			
-		}
-	}
-	
-	protected void processPaymentOk(PaymentOkEvent eventOk) {
-		log.debug("processPaymentOk() - Pay accepted");
+                        return;
+                }
+
+                if (pendingPayment != null) {
+                        log.debug("trayPay() - Pending payment context detected. It will be replaced by the new tender message.");
+                        pendingPayment = null;
+                }
+
+                PendingPaymentRequest paymentRequest = createPaymentRequest(message);
+
+                if (paymentRequest == null) {
+                        return;
+                }
+
+                if (paymentRequest.autoDetected) {
+                        pendingPayment = paymentRequest;
+                        sendAutoDetectedPaymentDialog(paymentRequest);
+                        return;
+                }
+
+                executePayment(paymentRequest);
+        }
+
+        protected PendingPaymentRequest createPaymentRequest(Tender message) {
+                String tenderType = message.getFieldValue(Tender.TenderType);
+                String numeroTarjeta = StringUtils.trimToNull(message.getFieldValue(Tender.UPC));
+
+                BigDecimal amount = extractAmount(message);
+
+                if (amount == null) {
+                        log.error("createPaymentRequest() - Amount received in tender message is not valid");
+                        sendTenderException(tenderType, "Importe no válido");
+                        return null;
+                }
+
+                String paymentMethodCode = resolvePaymentMethodCode(tenderType, numeroTarjeta);
+
+                if (StringUtils.isBlank(paymentMethodCode)) {
+                        log.error(String.format("createPaymentRequest() - Unable to resolve payment method for tender type %s", tenderType));
+                        sendTenderExceptionMessage("Medio de pago no encontrado");
+                        return null;
+                }
+
+                PaymentMethodManager paymentMethodManager = findPaymentMethodManager(paymentMethodCode);
+
+                if (paymentMethodManager == null) {
+                        log.error(String.format("createPaymentRequest() - Payment manager not found for code %s", paymentMethodCode));
+                        sendTenderExceptionMessage("Medio de pago no encontrado");
+                        return null;
+                }
+
+                MedioPagoBean medioPago = mediosPagosService.getMedioPago(paymentMethodCode);
+
+                boolean autoDetected = isAutoDetectedTender(tenderType);
+                boolean giftCard = isGiftCardManager(paymentMethodManager);
+
+                return new PendingPaymentRequest(message, paymentMethodCode, paymentMethodManager, medioPago, numeroTarjeta, amount, tenderType, autoDetected, giftCard);
+        }
+
+        protected BigDecimal extractAmount(Tender message) {
+                String amountValue = message.getFieldValue(Tender.Amount);
+
+                if (StringUtils.isBlank(amountValue)) {
+                        return null;
+                }
+
+                try {
+                        return new BigDecimal(amountValue).divide(new BigDecimal(100));
+                } catch (NumberFormatException e) {
+                        log.error("extractAmount() - Unable to parse tender amount: " + amountValue, e);
+                        return null;
+                }
+        }
+
+        protected String resolvePaymentMethodCode(String tenderType, String numeroTarjeta) {
+                if (isAutoDetectedTender(tenderType)) {
+                        return getPaymentCodeFromPrefixes(numeroTarjeta);
+                }
+
+                try {
+                        return scoTenderTypeToComerzziaPaymentCode(tenderType);
+                } catch (RuntimeException e) {
+                        log.error("resolvePaymentMethodCode() - Error resolving payment method code: " + e.getMessage(), e);
+                        return null;
+                }
+        }
+
+        protected String getPaymentCodeFromPrefixes(String numeroTarjeta) {
+                if (StringUtils.isBlank(numeroTarjeta)) {
+                        return null;
+                }
+
+                Object service = findPrefijosTarjetasService();
+
+                if (service == null) {
+                        log.warn("getPaymentCodeFromPrefixes() - PrefijosTarjetasService not available");
+                        return null;
+                }
+
+                try {
+                        Method method = service.getClass().getMethod("getMedioPagoPrefijo", String.class);
+                        Object result = method.invoke(service, numeroTarjeta);
+
+                        return result != null ? result.toString() : null;
+                } catch (Exception e) {
+                        log.error("getPaymentCodeFromPrefixes() - Error invoking getMedioPagoPrefijo: " + e.getMessage(), e);
+                        return null;
+                }
+        }
+
+        protected Object findPrefijosTarjetasService() {
+                for (String beanName : PREFIJOS_TARJETAS_BEAN_NAMES) {
+                        try {
+                                Object bean = ContextHolder.getBean(beanName);
+
+                                if (bean != null) {
+                                        return bean;
+                                }
+                        } catch (Exception e) {
+                                log.debug(String.format("findPrefijosTarjetasService() - Bean %s not found", beanName));
+                        }
+                }
+
+                for (String className : PREFIJOS_TARJETAS_CLASS_NAMES) {
+                        try {
+                                Class<?> clazz = Class.forName(className);
+
+                                Object bean = ContextHolder.get().getBean(clazz);
+
+                                if (bean != null) {
+                                        return bean;
+                                }
+                        } catch (ClassNotFoundException e) {
+                                log.debug(String.format("findPrefijosTarjetasService() - Class %s not found", className));
+                        } catch (Exception e) {
+                                log.debug(String.format("findPrefijosTarjetasService() - Unable to obtain bean for %s", className), e);
+                        }
+                }
+
+                return null;
+        }
+
+        protected PaymentMethodManager findPaymentMethodManager(String paymentMethodCode) {
+                PaymentsManager paymentsManager = ticketManager.getPaymentsManager();
+
+                if (paymentsManager == null) {
+                        return null;
+                }
+
+                Map<String, PaymentMethodManager> managers = getAvailablePaymentManagers(paymentsManager);
+
+                if (managers.containsKey(paymentMethodCode)) {
+                        return managers.get(paymentMethodCode);
+                }
+
+                try {
+                        Method method = paymentsManager.getClass().getMethod("getPaymentMethodManager", String.class);
+                        Object result = method.invoke(paymentsManager, paymentMethodCode);
+
+                        if (result instanceof PaymentMethodManager) {
+                                return (PaymentMethodManager) result;
+                        }
+                } catch (NoSuchMethodException e) {
+                        log.debug("findPaymentMethodManager() - getPaymentMethodManager method not available");
+                } catch (Exception e) {
+                        log.error("findPaymentMethodManager() - Error invoking getPaymentMethodManager: " + e.getMessage(), e);
+                }
+
+                return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        protected Map<String, PaymentMethodManager> getAvailablePaymentManagers(PaymentsManager paymentsManager) {
+                List<String> methodNames = Arrays.asList("getPaymentsMehtodManagerAvailables", "getPaymentsMethodManagerAvailables", "getPaymentMethodManagers");
+
+                for (String methodName : methodNames) {
+                        try {
+                                Method method = paymentsManager.getClass().getMethod(methodName);
+                                Object result = method.invoke(paymentsManager);
+
+                                if (result instanceof Map) {
+                                        return (Map<String, PaymentMethodManager>) result;
+                                }
+                        } catch (NoSuchMethodException e) {
+                                log.debug(String.format("getAvailablePaymentManagers() - Method %s not found", methodName));
+                        } catch (Exception e) {
+                                log.error(String.format("getAvailablePaymentManagers() - Error invoking %s: %s", methodName, e.getMessage()), e);
+                        }
+                }
+
+                return Collections.emptyMap();
+        }
+
+        protected boolean isAutoDetectedTender(String tenderType) {
+                return StringUtils.equalsIgnoreCase(OTHER_CARDS_TENDER_TYPE, StringUtils.trimToEmpty(tenderType));
+        }
+
+        protected boolean isGiftCardManager(PaymentMethodManager paymentMethodManager) {
+                if (paymentMethodManager == null) {
+                        return false;
+                }
+
+                String className = paymentMethodManager.getClass().getName();
+
+                return StringUtils.containsIgnoreCase(className, "VirtualMoneyManager")
+                                || StringUtils.containsIgnoreCase(className, "BalanceCardManager")
+                                || StringUtils.containsIgnoreCase(className, "GiftCardManager");
+        }
+
+        protected void sendAutoDetectedPaymentDialog(PendingPaymentRequest paymentRequest) {
+                DataNeeded dialog = new DataNeeded();
+                dialog.setFieldValue(DataNeeded.Type, DIALOG_CONFIRM_TYPE);
+                dialog.setFieldValue(DataNeeded.Id, DIALOG_CONFIRM_ID);
+                dialog.setFieldValue(DataNeeded.Mode, "0");
+
+                String description = paymentRequest.medioPago != null ? paymentRequest.medioPago.getDesMedioPago() : paymentRequest.paymentMethodCode;
+                String caption = MessageFormat.format("¿Desea usar su tarjeta {0}?", description);
+
+                dialog.setFieldValue(DataNeeded.TopCaption1, caption);
+                dialog.setFieldValue(DataNeeded.SummaryInstruction1, "Pulse una opción");
+                dialog.setFieldValue(DataNeeded.ButtonData1, "TxSi");
+                dialog.setFieldValue(DataNeeded.ButtonText1, "SI");
+                dialog.setFieldValue(DataNeeded.ButtonData2, "TxNo");
+                dialog.setFieldValue(DataNeeded.ButtonText2, "NO");
+                dialog.setFieldValue(DataNeeded.EnableScanner, "0");
+                dialog.setFieldValue(DataNeeded.HideGoBack, "1");
+
+                ncrController.sendMessage(dialog);
+        }
+
+        protected void executePayment(PendingPaymentRequest paymentRequest) {
+                PaymentsManager paymentsManager = ticketManager.getPaymentsManager();
+                BigDecimal amountToPay = paymentRequest.amount;
+                boolean waitStateSent = false;
+
+                try {
+                        if (paymentRequest.giftCard) {
+                                ncrController.sendWaitState("Validando tarjeta...");
+                                waitStateSent = true;
+
+                                try {
+                                        configureGiftCardManager(paymentRequest.paymentMethodManager, paymentRequest.numeroTarjeta);
+
+                                        BigDecimal balance = consultGiftCardBalance(paymentRequest.paymentMethodManager, paymentRequest.numeroTarjeta);
+
+                                        if (balance != null && amountToPay.compareTo(balance) > 0) {
+                                                amountToPay = balance;
+                                                paymentRequest.amount = balance;
+                                                paymentRequest.tenderMessage.setFieldIntValue(Tender.Amount, balance);
+                                        }
+                                } catch (Exception e) {
+                                        log.error("executePayment() - Error preparing gift card payment: " + e.getMessage(), e);
+                                }
+                        }
+
+                        if (StringUtils.equalsIgnoreCase("Credit", paymentRequest.scoTenderType)) {
+                                TenderException response = new TenderException();
+                                response.setFieldValue(TenderException.TenderType, paymentRequest.tenderMessage.getFieldValue(Tender.TenderType));
+                                response.setFieldValue(TenderException.ExceptionType, "0");
+                                response.setFieldValue(TenderException.ExceptionId, "1");
+                                ncrController.sendMessage(response);
+                        }
+
+                        paymentsManager.pay(paymentRequest.paymentMethodCode, amountToPay);
+                } catch (Exception e) {
+                        handlePaymentException(paymentsManager, e);
+                } finally {
+                        if (waitStateSent) {
+                                ncrController.sendFinishWaitState();
+                        }
+                }
+        }
+
+        protected void configureGiftCardManager(PaymentMethodManager paymentMethodManager, String numeroTarjeta) {
+                if (paymentMethodManager == null || StringUtils.isBlank(numeroTarjeta)) {
+                        return;
+                }
+
+                String parameterName = resolveCardNumberParameterName(paymentMethodManager);
+
+                paymentMethodManager.addParameter(parameterName, numeroTarjeta);
+        }
+
+        protected String resolveCardNumberParameterName(PaymentMethodManager paymentMethodManager) {
+                List<String> possibleNames = Arrays.asList("PARAM_NUMERO_TARJETA", "PARAM_TARJETA", DEFAULT_GIFT_CARD_PARAMETER, DEFAULT_GIFT_CARD_PARAMETER_ALTERNATIVE);
+
+                for (String fieldName : possibleNames) {
+                        String value = findStaticStringField(paymentMethodManager.getClass(), fieldName);
+
+                        if (StringUtils.isNotBlank(value)) {
+                                return value;
+                        }
+                }
+
+                return DEFAULT_GIFT_CARD_PARAMETER;
+        }
+
+        protected String findStaticStringField(Class<?> clazz, String fieldName) {
+                Class<?> current = clazz;
+
+                while (current != null) {
+                        try {
+                                Field field = current.getDeclaredField(fieldName);
+                                field.setAccessible(true);
+                                Object value = field.get(null);
+
+                                if (value instanceof String) {
+                                        return (String) value;
+                                }
+                        } catch (NoSuchFieldException e) {
+                                // continue searching in superclass
+                        } catch (Exception e) {
+                                log.debug(String.format("findStaticStringField() - Unable to read field %s from %s", fieldName, current.getName()), e);
+                        }
+
+                        current = current.getSuperclass();
+                }
+
+                return null;
+        }
+
+        protected BigDecimal consultGiftCardBalance(PaymentMethodManager paymentMethodManager, String numeroTarjeta) {
+                if (paymentMethodManager == null || StringUtils.isBlank(numeroTarjeta)) {
+                        return null;
+                }
+
+                try {
+                        Method method = paymentMethodManager.getClass().getMethod("consultarSaldo", String.class);
+                        Object account = method.invoke(paymentMethodManager, numeroTarjeta);
+
+                        return extractBalanceFromAccount(account);
+                } catch (NoSuchMethodException e) {
+                        log.debug("consultGiftCardBalance() - consultarSaldo method not available");
+                } catch (Exception e) {
+                        log.error("consultGiftCardBalance() - Error invoking consultarSaldo: " + e.getMessage(), e);
+                }
+
+                return null;
+        }
+
+        protected BigDecimal extractBalanceFromAccount(Object account) {
+                if (account == null) {
+                        return null;
+                }
+
+                try {
+                        Method principalBalanceMethod = account.getClass().getMethod("getPrincipaltBalance");
+                        Object principalBalance = principalBalanceMethod.invoke(account);
+
+                        if (principalBalance == null) {
+                                return null;
+                        }
+
+                        Method balanceMethod = principalBalance.getClass().getMethod("getBalance");
+                        Object balance = balanceMethod.invoke(principalBalance);
+
+                        if (balance instanceof BigDecimal) {
+                                return (BigDecimal) balance;
+                        }
+
+                        if (balance != null) {
+                                return new BigDecimal(balance.toString());
+                        }
+                } catch (Exception e) {
+                        log.error("extractBalanceFromAccount() - Error obtaining balance: " + e.getMessage(), e);
+                }
+
+                return null;
+        }
+
+        protected void sendCloseDataNeeded() {
+                DataNeeded closeMessage = new DataNeeded();
+                closeMessage.setFieldValue(DataNeeded.Type, "0");
+                closeMessage.setFieldValue(DataNeeded.Id, "0");
+                closeMessage.setFieldValue(DataNeeded.Mode, "0");
+
+                ncrController.sendMessage(closeMessage);
+        }
+
+        protected void sendTenderException(String tenderType, String message) {
+                TenderException error = new TenderException();
+                error.setFieldValue(TenderException.ExceptionId, "0");
+                error.setFieldValue(TenderException.ExceptionType, "0");
+
+                String tenderTypeValue = StringUtils.isNotBlank(tenderType) ? tenderType : message;
+
+                if (StringUtils.isNotBlank(tenderTypeValue)) {
+                        error.setFieldValue(TenderException.TenderType, tenderTypeValue);
+                }
+
+                if (StringUtils.isNotBlank(message)) {
+                        error.setFieldValue(TenderException.Message, message);
+                }
+
+                ncrController.sendMessage(error);
+        }
+
+        protected void sendTenderExceptionMessage(String message) {
+                sendTenderException(message, message);
+        }
+
+        public boolean handleDataNeededReply(DataNeededReply message) {
+                if (message == null) {
+                        return false;
+                }
+
+                if (!StringUtils.equals(DIALOG_CONFIRM_TYPE, message.getFieldValue(DataNeededReply.Type))
+                                || !StringUtils.equals(DIALOG_CONFIRM_ID, message.getFieldValue(DataNeededReply.Id))) {
+                        return false;
+                }
+
+                PendingPaymentRequest paymentRequest = pendingPayment;
+                pendingPayment = null;
+
+                sendCloseDataNeeded();
+
+                if (paymentRequest == null) {
+                        log.warn("handleDataNeededReply() - Received confirmation without pending payment context");
+                        return true;
+                }
+
+                String option = message.getFieldValue(DataNeededReply.Data1);
+
+                if (StringUtils.equalsIgnoreCase("TxSi", option)) {
+                        executePayment(paymentRequest);
+                } else {
+                        sendTenderException(paymentRequest.scoTenderType, "Operación cancelada por el usuario");
+                }
+
+                return true;
+        }
+
+        protected void handlePaymentException(PaymentsManager paymentsManager, Exception e) {
+                if (e instanceof PaymentException) {
+                        PaymentException paymentException = (PaymentException) e;
+                        PaymentErrorEvent errorEvent = new PaymentErrorEvent(this, paymentException.getPaymentId(), e, paymentException.getErrorCode(), paymentException.getMessage());
+                        PaymentsErrorEvent event = new PaymentsErrorEvent(this, errorEvent);
+                        paymentsManager.getEventsHandler().paymentsError(event);
+                } else {
+                        PaymentErrorEvent errorEvent = new PaymentErrorEvent(this, -1, e, null, null);
+                        PaymentsErrorEvent event = new PaymentsErrorEvent(this, errorEvent);
+                        paymentsManager.getEventsHandler().paymentsError(event);
+                }
+        }
+
+        protected static class PendingPaymentRequest {
+                protected final Tender tenderMessage;
+                protected final String paymentMethodCode;
+                protected final PaymentMethodManager paymentMethodManager;
+                protected final MedioPagoBean medioPago;
+                protected final String numeroTarjeta;
+                protected BigDecimal amount;
+                protected final String scoTenderType;
+                protected final boolean autoDetected;
+                protected final boolean giftCard;
+
+                protected PendingPaymentRequest(Tender tenderMessage, String paymentMethodCode, PaymentMethodManager paymentMethodManager,
+                                MedioPagoBean medioPago, String numeroTarjeta, BigDecimal amount, String scoTenderType,
+                                boolean autoDetected, boolean giftCard) {
+                        this.tenderMessage = tenderMessage;
+                        this.paymentMethodCode = paymentMethodCode;
+                        this.paymentMethodManager = paymentMethodManager;
+                        this.medioPago = medioPago;
+                        this.numeroTarjeta = numeroTarjeta;
+                        this.amount = amount;
+                        this.scoTenderType = scoTenderType;
+                        this.autoDetected = autoDetected;
+                        this.giftCard = giftCard;
+                }
+        }
+
+        protected void processPaymentOk(PaymentOkEvent eventOk) {
+                log.debug("processPaymentOk() - Pay accepted");
 		
 		BigDecimal amount = eventOk.getAmount();
 		String paymentCode = ((PaymentMethodManager) eventOk.getSource()).getPaymentCode();


### PR DESCRIPTION
## Summary
- extend the self-checkout PayManager to resolve gift-card tenders, configure the gift card manager with the scanned number, balance-check the card, and drive the wait/confirmation dialogs before calling the payment service
- delegate DataNeededReply handling in AmetllerCommandManager to the PayManager so auto-detected card confirmations are processed centrally

## Testing
- mvn -q -DskipTests package *(fails: blocked mirror for comerzzia repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c97f48fb78832bbb67a51bd4949e99