### PR TITLE
Ensure gift card payments refresh zero balances

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
@@ -375,8 +375,13 @@ public class AmetllerPayManager extends PayManager {
 
                     BigDecimal balance = extractBalanceFromGiftCardBean(giftCardData);
 
-                    if (balance == null) {
-                        balance = consultGiftCardBalance(paymentRequest.paymentMethodManager, paymentRequest.numeroTarjeta);
+                    if (balance == null || balance.compareTo(BigDecimal.ZERO) <= 0) {
+                        BigDecimal consultedBalance = consultGiftCardBalance(paymentRequest.paymentMethodManager,
+                                paymentRequest.numeroTarjeta);
+
+                        if (consultedBalance != null) {
+                            balance = consultedBalance;
+                        }
                     }
 
                     updateGiftCardBeanBalance(giftCardData, balance);


### PR DESCRIPTION
## Summary
- refresh the gift card balance from the payment manager whenever the locally obtained bean does not provide a positive balance
- keep using the recovered balance to cap the tender amount before delegating the payment

## Testing
- mvn -q -DskipTests compile *(fails: Blocked mirror for repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68ca9e1190cc832b8150f3038adad8d4