### PR TITLE
Use Fidelizados REST balance for gift cards

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
@@ -373,30 +373,65 @@ public class AmetllerPayManager extends PayManager {
                 try {
                     giftCardData = configureGiftCardManager(paymentRequest);
 
-                    BigDecimal balance = extractBalanceFromGiftCardBean(giftCardData);
+                    BigDecimal balance = null;
 
-                    if (balance == null || balance.compareTo(BigDecimal.ZERO) <= 0) {
+                    Object restGiftCard = fetchGiftCardBeanFromFidelizados(paymentRequest.numeroTarjeta);
+
+                    if (restGiftCard != null) {
+                        balance = applyGiftCardRestData(giftCardData, restGiftCard);
+
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug(String.format(
+                                    "executePayment() - Obtained gift card balance from REST service: %s",
+                                    balance));
+                        }
+                    }
+
+                    if (balance == null) {
+                        balance = extractBalanceFromGiftCardBean(giftCardData);
+                    }
+
+                    if (balance == null) {
+                        LOG.debug(
+                                "executePayment() - Gift card balance not available from REST, falling back to legacy consultation");
+
                         BigDecimal consultedBalance = consultGiftCardBalance(paymentRequest.paymentMethodManager,
                                 paymentRequest.numeroTarjeta);
 
                         if (consultedBalance != null) {
                             balance = consultedBalance;
+
+                            if (giftCardData != null) {
+                                ensureGiftCardBalanceInitialized(giftCardData, balance, BigDecimal.ZERO);
+                                invokeSetter(giftCardData, "setSaldoTotal", BigDecimal.class, balance);
+                            }
                         }
                     }
 
-                    updateGiftCardBeanBalance(giftCardData, balance);
+                    if (giftCardData != null && balance != null) {
+                        invokeSetter(giftCardData, "setSaldoTotal", BigDecimal.class, balance);
+                        updateGiftCardBeanBalance(giftCardData, balance);
+                    }
 
                     if (balance != null && balance.compareTo(BigDecimal.ZERO) > 0
                             && amountToPay.compareTo(balance) > 0) {
+                        LOG.info(String.format(
+                                "executePayment() - Gift card balance %s lower than requested amount %s. Adjusting tender amount.",
+                                balance, amountToPay));
                         amountToPay = balance;
-                        paymentRequest.amount = balance;
-                        paymentRequest.tenderMessage.setFieldIntValue(Tender.Amount, balance);
                     }
                 } catch (Exception e) {
                     LOG.error("executePayment() - Error preparing gift card payment: " + e.getMessage(), e);
                 } finally {
-                    updateGiftCardBeanAmount(giftCardData, paymentRequest.amount);
+                    paymentRequest.amount = amountToPay;
+                    updateGiftCardBeanAmount(giftCardData, amountToPay);
                 }
+            }
+
+            paymentRequest.amount = amountToPay;
+
+            if (paymentRequest.tenderMessage != null && amountToPay != null) {
+                paymentRequest.tenderMessage.setFieldIntValue(Tender.Amount, amountToPay);
             }
 
             if (StringUtils.equalsIgnoreCase("Credit", paymentRequest.scoTenderType)) {
@@ -644,6 +679,43 @@ public class AmetllerPayManager extends PayManager {
         return null;
     }
 
+    private Object fetchGiftCardBeanFromFidelizados(String numeroTarjeta) {
+        if (StringUtils.isBlank(numeroTarjeta)) {
+            return null;
+        }
+
+        try {
+            Class<?> restClass = Class.forName("com.comerzzia.api.rest.client.fidelizados.FidelizadosRest");
+
+            for (Method method : restClass.getMethods()) {
+                if (!StringUtils.equals(method.getName(), "getTarjetaRegalo")
+                        || !Modifier.isStatic(method.getModifiers())) {
+                    continue;
+                }
+
+                Object[] arguments = buildRestArguments(method.getParameterTypes(), numeroTarjeta);
+
+                if (arguments == null) {
+                    LOG.debug("fetchGiftCardBeanFromFidelizados() - Unsupported getTarjetaRegalo signature");
+                    continue;
+                }
+
+                try {
+                    return method.invoke(null, arguments);
+                } catch (Exception e) {
+                    LOG.error("fetchGiftCardBeanFromFidelizados() - Error invoking getTarjetaRegalo: "
+                            + e.getMessage(), e);
+                }
+            }
+
+            LOG.debug("fetchGiftCardBeanFromFidelizados() - getTarjetaRegalo method not available");
+        } catch (ClassNotFoundException e) {
+            LOG.debug("fetchGiftCardBeanFromFidelizados() - FidelizadosRest class not available");
+        }
+
+        return null;
+    }
+
     private Object adaptGiftCardResult(Object result, String numeroTarjeta, BigDecimal amount) {
         if (result == null) {
             return null;
@@ -706,6 +778,59 @@ public class AmetllerPayManager extends PayManager {
         }
 
         return null;
+    }
+
+    private BigDecimal applyGiftCardRestData(Object giftCardBean, Object restGiftCard) {
+        if (restGiftCard == null) {
+            return null;
+        }
+
+        BigDecimal saldo = extractBigDecimal(restGiftCard, "getSaldo");
+        BigDecimal saldoProvisional = extractBigDecimal(restGiftCard, "getSaldoProvisional");
+        BigDecimal saldoTotal = extractBigDecimal(restGiftCard, "getSaldoTotal");
+
+        if (giftCardBean != null) {
+            if (saldo != null) {
+                invokeSetter(giftCardBean, "setSaldo", BigDecimal.class, saldo);
+            }
+
+            if (saldoProvisional != null) {
+                invokeSetter(giftCardBean, "setSaldoProvisional", BigDecimal.class, saldoProvisional);
+            }
+
+            if (saldo != null || saldoProvisional != null) {
+                ensureGiftCardBalanceInitialized(giftCardBean, saldo, saldoProvisional);
+            }
+
+            BigDecimal totalToApply = saldoTotal;
+
+            if (totalToApply == null && (saldo != null || saldoProvisional != null)) {
+                BigDecimal saldoValue = saldo != null ? saldo : BigDecimal.ZERO;
+                BigDecimal provisionalValue = saldoProvisional != null ? saldoProvisional : BigDecimal.ZERO;
+                totalToApply = saldoValue.add(provisionalValue);
+            }
+
+            if (totalToApply != null) {
+                invokeSetter(giftCardBean, "setSaldoTotal", BigDecimal.class, totalToApply);
+
+                if (saldo == null && saldoProvisional == null) {
+                    ensureGiftCardBalanceInitialized(giftCardBean, totalToApply, BigDecimal.ZERO);
+                }
+            }
+        }
+
+        if (saldoTotal != null) {
+            return saldoTotal;
+        }
+
+        if (saldo == null && saldoProvisional == null) {
+            return null;
+        }
+
+        BigDecimal saldoValue = saldo != null ? saldo : BigDecimal.ZERO;
+        BigDecimal provisionalValue = saldoProvisional != null ? saldoProvisional : BigDecimal.ZERO;
+
+        return saldoValue.add(provisionalValue);
     }
 
     private Object invokeGiftCardLookup(Object candidate, String numeroTarjeta) {


### PR DESCRIPTION
## Summary
- fetch gift card information through `FidelizadosRest#getTarjetaRegalo` before completing a payment
- apply the REST balance to the gift card bean that is provided to the payment manager and fall back to the legacy lookup when needed
- recalculate the tender amount with the real balance, update the NCR message, and add logging that shows when the amount is adjusted

## Testing
- mvn -q -DskipTests package *(fails: blocked access to Comerzzia Maven repositories in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caa4db15cc832b8544b606c1fc1f36