### PR TITLE
Handle Descuento 25 data needed reply in pay manager

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
@@ -54,6 +54,9 @@ public class AmetllerPayManager extends PayManager {
     private static final String DIALOG_CONFIRM_TYPE = "4";
     private static final String DIALOG_CONFIRM_ID   = "1";
 
+    private static final String DESCUENTO25_DIALOG_TYPE = "1";
+    private static final String DESCUENTO25_DIALOG_ID   = "2";
+
     // WAIT overlay del SCO (ojo: en tu log abre Type=1, Id=1 "Validando tarjeta...")
     private static final String WAIT_TYPE = "1";
     private static final String WAIT_ID   = "1";
@@ -73,11 +76,14 @@ public class AmetllerPayManager extends PayManager {
     @Override
     public void processMessage(BasicNCRMessage message) {
         if (message instanceof DataNeededReply) {
-            if (!handleDataNeededReply((DataNeededReply) message)) {
+            DataNeededReply reply = (DataNeededReply) message;
+            if (handleDescuento25DataNeededReply(reply)) {
+                return;
+            }
+            if (!handleDataNeededReply(reply)) {
                 // Consumir los DataNeededReply vacíos (Type=0/Id=0) para no dejar colas abiertas
-                DataNeededReply r = (DataNeededReply) message;
-                String t = StringUtils.defaultString(r.getFieldValue(DataNeededReply.Type));
-                String i = StringUtils.defaultString(r.getFieldValue(DataNeededReply.Id));
+                String t = StringUtils.defaultString(reply.getFieldValue(DataNeededReply.Type));
+                String i = StringUtils.defaultString(reply.getFieldValue(DataNeededReply.Id));
                 if ("0".equals(t) && "0".equals(i)) return;
                 log.warn("processMessage() - DataNeededReply not managed by gift card flow");
             }
@@ -213,6 +219,18 @@ public class AmetllerPayManager extends PayManager {
             sendGiftCardError(I18N.getTexto("Operación cancelada por el usuario"), payment.context.scoTenderType);
             itemsManager.sendTotals();
         }
+        return true;
+    }
+
+    private boolean handleDescuento25DataNeededReply(DataNeededReply reply) {
+        String type = reply.getFieldValue(DataNeededReply.Type);
+        String id   = reply.getFieldValue(DataNeededReply.Id);
+
+        if (!DESCUENTO25_DIALOG_TYPE.equals(type) || !DESCUENTO25_DIALOG_ID.equals(id)) {
+            return false;
+        }
+
+        sendCloseDialog();
         return true;
     }
 


### PR DESCRIPTION
## Summary
- handle the SCO 25% discount DataNeededReply within `AmetllerPayManager` so the confirmation dialog closes without interfering with the gift card flow
- define constants for the Descuento 25 dialog identifiers used by the new handling logic

## Testing
- `mvn -q -DskipTests package` *(fails: blocked access to `org.apache.maven.plugins:maven-resources-plugin` from the internal mirror)*

------
https://chatgpt.com/codex/tasks/task_e_68cb3e840158832b892ffcb6bbf01117