### PR TITLE
feat: show ItemException after coupon scan in Ametller

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
@@ -9,9 +9,11 @@ import org.springframework.stereotype.Service;
 
 import com.comerzzia.ametller.pos.ncr.ticket.AmetllerScoTicketManager;
 import com.comerzzia.pos.ncr.actions.sale.ItemsManager;
+import com.comerzzia.pos.ncr.messages.ItemException;
 import com.comerzzia.pos.ncr.messages.ItemSold;
 import com.comerzzia.pos.services.ticket.lineas.LineaTicket;
 import com.comerzzia.pos.util.bigdecimal.BigDecimalUtil;
+import com.comerzzia.pos.util.i18n.I18N;
 
 @Lazy(false)
 @Service
@@ -23,7 +25,7 @@ public class AmetllerItemsManager extends ItemsManager {
 
     @Override
     protected ItemSold lineaTicketToItemSold(LineaTicket linea) {
-		ItemSold itemSold = super.lineaTicketToItemSold(linea);
+                ItemSold itemSold = super.lineaTicketToItemSold(linea);
 
         if (linea != null && itemSold != null && ticketManager instanceof AmetllerScoTicketManager) {
             AmetllerScoTicketManager ametllerScoTicketManager = (AmetllerScoTicketManager) ticketManager;
@@ -44,5 +46,26 @@ public class AmetllerItemsManager extends ItemsManager {
         }
 
         return itemSold;
+    }
+
+    @Override
+    public boolean isCoupon(String code) {
+        boolean couponAlreadyApplied = globalDiscounts.containsKey(GLOBAL_DISCOUNT_COUPON_PREFIX + code);
+
+        boolean handled = super.isCoupon(code);
+
+        boolean couponApplied = globalDiscounts.containsKey(GLOBAL_DISCOUNT_COUPON_PREFIX + code);
+
+        if (handled && couponApplied && !couponAlreadyApplied) {
+            ItemException itemException = new ItemException();
+            itemException.setFieldValue(ItemException.UPC, "");
+            itemException.setFieldValue(ItemException.ExceptionType, "0");
+            itemException.setFieldValue(ItemException.ExceptionId, "25");
+            itemException.setFieldValue(ItemException.Message, I18N.getTexto("Tu cupon ha sido leído correctamente"));
+            itemException.setFieldValue(ItemException.TopCaption, I18N.getTexto("Cupon leído"));
+            ncrController.sendMessage(itemException);
+        }
+
+        return handled;
     }
 }


### PR DESCRIPTION
## Summary
- override the Ametller coupon flow to emit an ItemException after a successful scan
- reuse the base coupon handling while adding the confirmation message shown in Dinosol

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d684d4d8c0832b85abee1e933396a9