### PR TITLE
Disable NCR wait DataNeeded cleanup to avoid lock-ups

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
@@ -76,6 +76,15 @@ public class AmetllerPayManager extends PayManager {
 	private static final String WAIT_TYPE = "1";
 	private static final String WAIT_ID = "1";
 
+	/**
+	 * NCR SCO no soporta correctamente los mensajes de cierre de DataNeeded y
+	 * bloquea el flujo cuando se envían tras finalizar la transacción. Para
+	 * evitarlo, se desactiva el envío de los diálogos de espera/cierre
+	 * automáticos.
+	 */
+	private static final boolean ENABLE_WAIT_DIALOG_MESSAGES = false;
+	private static final boolean ENABLE_GENERIC_CLOSE_MESSAGE = false;
+
 	private static final String RECEIPT_SEPARATOR = "------------------------------";
 	private static final Locale RECEIPT_LOCALE = new Locale("es", "ES");
 
@@ -272,8 +281,14 @@ public class AmetllerPayManager extends PayManager {
 		return true;
 	}
 
-	// ==== WAIT control explícito ====
+        	// ==== WAIT control explícito ====
 	private void sendShowWait(String caption) {
+		if (!ENABLE_WAIT_DIALOG_MESSAGES) {
+			if (log.isDebugEnabled()) {
+				log.debug("sendShowWait() - Suppressed wait dialog to avoid NCR lock-up");
+			}
+			return;
+		}
 		DataNeeded w = new DataNeeded();
 		w.setFieldValue(DataNeeded.Type, WAIT_TYPE);
 		w.setFieldValue(DataNeeded.Id, WAIT_ID);
@@ -285,6 +300,12 @@ public class AmetllerPayManager extends PayManager {
 	}
 
 	private void sendHideWait() {
+		if (!ENABLE_WAIT_DIALOG_MESSAGES) {
+			if (log.isDebugEnabled()) {
+				log.debug("sendHideWait() - Suppressed wait dialog close to avoid NCR lock-up");
+			}
+			return;
+		}
 		DataNeeded w = new DataNeeded();
 		w.setFieldValue(DataNeeded.Type, WAIT_TYPE);
 		w.setFieldValue(DataNeeded.Id, WAIT_ID);
@@ -304,6 +325,12 @@ public class AmetllerPayManager extends PayManager {
 	}
 
 	private void sendCloseDialog() {
+		if (!ENABLE_GENERIC_CLOSE_MESSAGE) {
+			if (log.isDebugEnabled()) {
+				log.debug("sendCloseDialog() - Suppressed generic DataNeeded close to avoid NCR lock-up");
+			}
+			return;
+		}
 		DataNeeded close = new DataNeeded();
 		close.setFieldValue(DataNeeded.Type, "0");
 		close.setFieldValue(DataNeeded.Id, "0");


### PR DESCRIPTION
## Summary
- disable the NCR wait dialog and generic DataNeeded close messages in the Ametller tender flow to prevent the SCO from blocking after a gift card payment

## Testing
- mvn -q -DskipTests package *(fails: blocked access to internal Maven repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68da64c8861c832b92c3294d6ea12351