### PR TITLE
Restore 25% discount dialog close while keeping gift card DataNeeded suppressed

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
@@ -76,6 +76,15 @@ public class AmetllerPayManager extends PayManager {
 	private static final String WAIT_TYPE = "1";
 	private static final String WAIT_ID = "1";
 
+	/**
+	 * NCR SCO no soporta correctamente los mensajes de cierre de DataNeeded y
+	 * bloquea el flujo cuando se envían tras finalizar la transacción. Para
+	 * evitarlo, se desactiva el envío de los diálogos de espera/cierre
+	 * automáticos.
+	 */
+	private static final boolean ENABLE_WAIT_DIALOG_MESSAGES = false;
+	private static final boolean SUPPRESS_GENERIC_CLOSE_MESSAGE = true;
+
 	private static final String RECEIPT_SEPARATOR = "------------------------------";
 	private static final Locale RECEIPT_LOCALE = new Locale("es", "ES");
 
@@ -268,12 +277,18 @@ public class AmetllerPayManager extends PayManager {
 		}
 
 		sendCloseDialog(DESCUENTO25_DIALOG_TYPE, DESCUENTO25_DIALOG_ID);
-		sendCloseDialog();
+		sendCloseDialog(true);
 		return true;
 	}
 
-	// ==== WAIT control explícito ====
+        	// ==== WAIT control explícito ====
 	private void sendShowWait(String caption) {
+		if (!ENABLE_WAIT_DIALOG_MESSAGES) {
+			if (log.isDebugEnabled()) {
+				log.debug("sendShowWait() - Suppressed wait dialog to avoid NCR lock-up");
+			}
+			return;
+		}
 		DataNeeded w = new DataNeeded();
 		w.setFieldValue(DataNeeded.Type, WAIT_TYPE);
 		w.setFieldValue(DataNeeded.Id, WAIT_ID);
@@ -285,6 +300,12 @@ public class AmetllerPayManager extends PayManager {
 	}
 
 	private void sendHideWait() {
+		if (!ENABLE_WAIT_DIALOG_MESSAGES) {
+			if (log.isDebugEnabled()) {
+				log.debug("sendHideWait() - Suppressed wait dialog close to avoid NCR lock-up");
+			}
+			return;
+		}
 		DataNeeded w = new DataNeeded();
 		w.setFieldValue(DataNeeded.Type, WAIT_TYPE);
 		w.setFieldValue(DataNeeded.Id, WAIT_ID);
@@ -304,6 +325,16 @@ public class AmetllerPayManager extends PayManager {
 	}
 
 	private void sendCloseDialog() {
+		sendCloseDialog(false);
+	}
+
+	private void sendCloseDialog(boolean force) {
+		if (!force && SUPPRESS_GENERIC_CLOSE_MESSAGE) {
+			if (log.isDebugEnabled()) {
+				log.debug("sendCloseDialog(force=false) - Suppressed generic DataNeeded close to avoid NCR lock-up");
+			}
+			return;
+		}
 		DataNeeded close = new DataNeeded();
 		close.setFieldValue(DataNeeded.Type, "0");
 		close.setFieldValue(DataNeeded.Id, "0");
@@ -325,7 +356,9 @@ public class AmetllerPayManager extends PayManager {
 	}
 
 	private void executeGiftCardPayment(PendingPayment payment) {
-		sendShowWait(I18N.getTexto("Validando tarjeta..."));
+                if (ENABLE_WAIT_DIALOG_MESSAGES) {
+                        sendShowWait(I18N.getTexto("Validando tarjeta..."));
+                }
 
 		try {
 			GiftCardBean giftCard = consultGiftCard(payment.cardNumber);
@@ -348,22 +381,28 @@ public class AmetllerPayManager extends PayManager {
 			PaymentsManager pm = ticketManager.getPaymentsManager();
 			pm.pay(payment.context.paymentCode, amountToCharge);
 
-			sendHideWait();
-			sendCloseDialog();
+                        if (ENABLE_WAIT_DIALOG_MESSAGES) {
+                                sendHideWait();
+                        }
+                        sendCloseDialog();
 
-		}
-		catch (GiftCardException e) {
-			log.error("executeGiftCardPayment() - " + e.getMessage(), e);
-			sendGiftCardError(e.getMessage(), payment.context.scoTenderType);
-			sendHideWait();
-			sendCloseDialog();
-		}
-		catch (Exception e) {
-			log.error("executeGiftCardPayment() - Unexpected error: " + e.getMessage(), e);
-			sendGiftCardError(I18N.getTexto("No se ha podido validar la tarjeta regalo."), payment.context.scoTenderType);
-			sendHideWait();
-			sendCloseDialog();
-		}
+                }
+                catch (GiftCardException e) {
+                        log.error("executeGiftCardPayment() - " + e.getMessage(), e);
+                        sendGiftCardError(e.getMessage(), payment.context.scoTenderType);
+                        if (ENABLE_WAIT_DIALOG_MESSAGES) {
+                                sendHideWait();
+                        }
+                        sendCloseDialog();
+                }
+                catch (Exception e) {
+                        log.error("executeGiftCardPayment() - Unexpected error: " + e.getMessage(), e);
+                        sendGiftCardError(I18N.getTexto("No se ha podido validar la tarjeta regalo."), payment.context.scoTenderType);
+                        if (ENABLE_WAIT_DIALOG_MESSAGES) {
+                                sendHideWait();
+                        }
+                        sendCloseDialog();
+                }
 	}
 
 	@Override


### PR DESCRIPTION
## Summary
- replace the global generic close flag with a suppression constant so the gift card flow keeps the end-of-payment DataNeeded hidden
- allow the Descuento25 confirmation handler to force the generic DataNeeded close that the 25% discount button expects
- add an overload of sendCloseDialog that optionally emits the generic close message while keeping it suppressed by default

## Testing
- mvn -q -DskipTests package *(fails: blocked access to internal Maven repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68da64c8861c832b92c3294d6ea12351