### PR TITLE
Disable SCO gift card confirmation dialog

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
@@ -73,8 +73,10 @@ public class AmetllerPayManager extends PayManager {
 	private static final String DESCUENTO25_DIALOG_TYPE = "1";
 	private static final String DESCUENTO25_DIALOG_ID = "2";
 
-	private static final String WAIT_TYPE = "1";
-	private static final String WAIT_ID = "1";
+        private static final String WAIT_TYPE = "1";
+        private static final String WAIT_ID = "1";
+
+        private static final boolean ENABLE_GIFTCARD_CONFIRMATION = false;
 
 	/**
 	 * NCR SCO no soporta correctamente los mensajes de cierre de DataNeeded y
@@ -104,17 +106,27 @@ public class AmetllerPayManager extends PayManager {
 
 	@Override
 	public void processMessage(BasicNCRMessage message) {
-		if (message instanceof DataNeededReply) {
-			DataNeededReply reply = (DataNeededReply) message;
-			if (handleDescuento25DataNeededReply(reply)) {
-				return;
-			}
-			if (!handleDataNeededReply(reply)) {
-				String t = StringUtils.trimToEmpty(reply.getFieldValue(DataNeededReply.Type));
-				String i = StringUtils.trimToEmpty(reply.getFieldValue(DataNeededReply.Id));
-				if ("0".equals(t) && "0".equals(i))
-					return;
-				log.warn("processMessage() - DataNeededReply not managed by gift card flow");
+                if (message instanceof DataNeededReply) {
+                        DataNeededReply reply = (DataNeededReply) message;
+                        if (handleDescuento25DataNeededReply(reply)) {
+                                return;
+                        }
+                        if (!ENABLE_GIFTCARD_CONFIRMATION) {
+                                if (log.isDebugEnabled()) {
+                                        String t = StringUtils.trimToEmpty(reply.getFieldValue(DataNeededReply.Type));
+                                        String i = StringUtils.trimToEmpty(reply.getFieldValue(DataNeededReply.Id));
+                                        if (StringUtils.equals(t, DIALOG_CONFIRM_TYPE) && StringUtils.equals(i, DIALOG_CONFIRM_ID)) {
+                                                log.debug("processMessage() - Gift card confirmation dialog disabled; ignoring DataNeededReply");
+                                        }
+                                }
+                                return;
+                        }
+                        if (!handleDataNeededReply(reply)) {
+                                String t = StringUtils.trimToEmpty(reply.getFieldValue(DataNeededReply.Type));
+                                String i = StringUtils.trimToEmpty(reply.getFieldValue(DataNeededReply.Id));
+                                if ("0".equals(t) && "0".equals(i))
+                                        return;
+                                log.warn("processMessage() - DataNeededReply not managed by gift card flow");
 			}
 			return;
 		}
@@ -152,15 +164,15 @@ public class AmetllerPayManager extends PayManager {
 			return;
 		}
 
-		PendingPayment payment = new PendingPayment(message, context, cardNumber, amount);
+                PendingPayment payment = new PendingPayment(message, context, cardNumber, amount);
 
-		if (context.requiresConfirmation) {
-			pendingPayment = payment;
-			sendConfirmationDialog(context);
-			return;
-		}
-		executeGiftCardPayment(payment);
-	}
+                if (ENABLE_GIFTCARD_CONFIRMATION && context.requiresConfirmation) {
+                        pendingPayment = payment;
+                        sendConfirmationDialog(context);
+                        return;
+                }
+                executeGiftCardPayment(payment);
+        }
 
 	private GiftCardContext resolveGiftCardContext(String tenderTypeRaw, String normalizedTender, String cardNumber, PaymentsManager paymentsManager) {
 		if (paymentsManager == null)


### PR DESCRIPTION
## Summary
- disable the SCO gift card confirmation DataNeeded dialog so the UI no longer shows the extra prompt
- keep the payment flow intact by executing gift card payments immediately when the confirmation feature is disabled

## Testing
- `mvn -q -DskipTests package` *(fails: missing internal Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68da70ac32ec832bbf471fecbc786793