### PR TITLE
Ensure gift card DataNeededReply handled by pay manager

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
@@ -26,6 +26,7 @@ import javax.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -59,6 +60,7 @@ import com.comerzzia.pos.util.i18n.I18N;
 @Lazy(false)
 @Service
 @Primary
+@DependsOn("ametllerCommandManager")
 public class AmetllerPayManager extends PayManager {
 
 	private static final Logger log = Logger.getLogger(AmetllerPayManager.class);


### PR DESCRIPTION
## Summary
- enforce that `AmetllerPayManager` is initialized after `AmetllerCommandManager` so it keeps ownership of `DataNeededReply`
- ensure the packaged execution keeps processing gift-card confirmations instead of getting stuck in the confirmation dialog

## Testing
- `mvn -q -DskipTests package` *(fails: dependency resolution blocked by private mirrors)*

------
https://chatgpt.com/codex/tasks/task_e_68de2e1e1dc8832b8fc31f3c92f1cfb4