### PR TITLE
Fix pending amount for header discount payments

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -51,11 +52,15 @@ import com.comerzzia.pos.services.core.variables.VariablesServices;
 import com.comerzzia.pos.services.payments.PaymentsManager;
 import com.comerzzia.pos.services.payments.methods.PaymentMethodManager;
 import com.comerzzia.pos.services.payments.methods.types.GiftCardManager;
+import com.comerzzia.pos.persistence.promociones.tipos.PromocionTipoBean;
 import com.comerzzia.pos.services.ticket.ITicket;
 import com.comerzzia.pos.services.ticket.cabecera.ITotalesTicket;
 import com.comerzzia.pos.services.ticket.lineas.LineaTicket;
+import com.comerzzia.pos.services.ticket.pagos.IPagoTicket;
 import com.comerzzia.pos.services.ticket.pagos.PagoTicket;
+import com.comerzzia.pos.services.ticket.promociones.PromocionTicket;
 import com.comerzzia.pos.util.i18n.I18N;
+import com.comerzzia.pos.util.bigdecimal.BigDecimalUtil;
 
 @Lazy(false)
 @Service
@@ -120,6 +125,58 @@ public class AmetllerPayManager extends PayManager {
 			((AmetllerScoTicketManager) ticketManager).setDescuento25Activo(false);
 		}
 		super.activateTenderMode();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	protected void addHeaderDiscountsPayments() {
+		Map<String, BigDecimal> descuentosPromocionales = new HashMap<String, BigDecimal>();
+
+		for (PromocionTicket promocion : (List<PromocionTicket>) ticketManager.getTicket().getPromociones()) {
+			if (promocion.isDescuentoMenosIngreso()) {
+				PromocionTipoBean tipoPromocion = ticketManager.getSesion().getSesionPromociones()
+						.getPromocionActiva(promocion.getIdPromocion()).getPromocionBean()
+						.getTipoPromocion();
+				String codMedioPago = tipoPromocion.getCodMedioPagoMenosIngreso();
+				if (codMedioPago != null) {
+					BigDecimal importeDescPromocional = BigDecimalUtil
+							.redondear(promocion.getImporteTotalAhorro(), 2);
+					BigDecimal importeDescAcum = descuentosPromocionales.get(codMedioPago) != null
+							? descuentosPromocionales.get(codMedioPago)
+							: BigDecimal.ZERO;
+					importeDescAcum = importeDescAcum.add(importeDescPromocional);
+					descuentosPromocionales.put(codMedioPago, importeDescAcum);
+				}
+			}
+		}
+
+		ticketManager.getTicket().getPagos().removeIf(p -> {
+			if (!(p instanceof IPagoTicket)) {
+				return false;
+			}
+
+			IPagoTicket pagoTicket = (IPagoTicket) p;
+
+			if (!pagoTicket.isIntroducidoPorCajero()) {
+				return true;
+			}
+
+			MedioPagoBean medioPago = pagoTicket.getMedioPago();
+
+			return medioPago != null && descuentosPromocionales.containsKey(medioPago.getCodMedioPago());
+		});
+		ticketManager.getTicket().getCabecera().getTotales().recalcular();
+
+		for (Map.Entry<String, BigDecimal> descuento : descuentosPromocionales.entrySet()) {
+			String codMedioPago = descuento.getKey();
+			BigDecimal importe = descuento.getValue();
+
+			if (BigDecimalUtil.isMayorACero(importe)) {
+				ticketManager.addPayToTicket(codMedioPago, importe, null, true, false);
+			}
+		}
+
+		ticketManager.getTicket().getCabecera().getTotales().recalcular();
 	}
 
 	@Override

--- a/src/main/java/com/comerzzia/pos/ncr/actions/sale/PayManager.java
+++ b/src/main/java/com/comerzzia/pos/ncr/actions/sale/PayManager.java
@@ -69,50 +69,35 @@ public class PayManager implements ActionManager {
 	protected MediosPagosService mediosPagosService;
 	
 	@SuppressWarnings("unchecked")
-        protected void addHeaderDiscountsPayments() {
-                Map<String, BigDecimal> descuentosPromocionales = new HashMap<String, BigDecimal>();
-
-                for(PromocionTicket promocion : (List<PromocionTicket>) ticketManager.getTicket().getPromociones()) {
-                        if(promocion.isDescuentoMenosIngreso()) {
-                                PromocionTipoBean tipoPromocion = ticketManager.getSesion().getSesionPromociones().getPromocionActiva(promocion.getIdPromocion()).getPromocionBean().getTipoPromocion();
-                                String codMedioPago = tipoPromocion.getCodMedioPagoMenosIngreso();
+	protected void addHeaderDiscountsPayments() {
+		ticketManager.getTicket().getPagos().removeIf(p->!((IPagoTicket)p).isIntroducidoPorCajero());
+		ticketManager.getTicket().getCabecera().getTotales().recalcular();
+		
+		Map<String, BigDecimal> descuentosPromocionales = new HashMap<String, BigDecimal>();
+		
+		for(PromocionTicket promocion : (List<PromocionTicket>) ticketManager.getTicket().getPromociones()) {
+			if(promocion.isDescuentoMenosIngreso()) {
+				PromocionTipoBean tipoPromocion = ticketManager.getSesion().getSesionPromociones().getPromocionActiva(promocion.getIdPromocion()).getPromocionBean().getTipoPromocion();
+				String codMedioPago = tipoPromocion.getCodMedioPagoMenosIngreso();
 				if(codMedioPago != null) {
 					BigDecimal importeDescPromocional = BigDecimalUtil.redondear(promocion.getImporteTotalAhorro(), 2);
 					BigDecimal importeDescAcum = descuentosPromocionales.get(codMedioPago) != null ? descuentosPromocionales.get(codMedioPago) : BigDecimal.ZERO;
 					importeDescAcum = importeDescAcum.add(importeDescPromocional);
 					descuentosPromocionales.put(codMedioPago, importeDescAcum);
-                                }
-                        }
-                }
-
-                ticketManager.getTicket().getPagos().removeIf(p -> {
-                        if (!(p instanceof IPagoTicket)) {
-                                return false;
-                        }
-
-                        IPagoTicket pagoTicket = (IPagoTicket) p;
-
-                        if (!pagoTicket.isIntroducidoPorCajero()) {
-                                return true;
-                        }
-
-                        MedioPagoBean medioPago = pagoTicket.getMedioPago();
-
-                        return medioPago != null && descuentosPromocionales.containsKey(medioPago.getCodMedioPago());
-                });
-                ticketManager.getTicket().getCabecera().getTotales().recalcular();
-
-                for(Map.Entry<String, BigDecimal> descuento : descuentosPromocionales.entrySet()) {
-                        String codMedioPago = descuento.getKey();
-                        BigDecimal importe = descuento.getValue();
-
-                        if(BigDecimalUtil.isMayorACero(importe)) {
-                                ticketManager.addPayToTicket(codMedioPago, importe, null, true, false);
-                        }
-                }
-
-                ticketManager.getTicket().getCabecera().getTotales().recalcular();
-        }
+				}
+			}
+		}
+		
+		for(String codMedioPago : descuentosPromocionales.keySet()) {
+			BigDecimal importe = descuentosPromocionales.get(codMedioPago);
+			
+			if(BigDecimalUtil.isMayorACero(importe)) {
+				ticketManager.addPayToTicket(codMedioPago, importe, null, false, false);
+			}
+		}
+		
+		ticketManager.getTicket().getCabecera().getTotales().recalcular();
+	}
 
 	@Override
 	public void processMessage(BasicNCRMessage message) {


### PR DESCRIPTION
## Summary
- recalculate header discount payments by medio de pago and remove outdated auto-generated entries
- re-add discount payments as cashier-entered so the payments manager counts them when computing the pending balance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de6d878770832b88e3cc6391ba586d