### PR TITLE
Ensure loyalty promotions refresh line discounts

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
@@ -27,6 +27,19 @@ public class AmetllerItemsManager extends ItemsManager {
     protected ItemSold lineaTicketToItemSold(LineaTicket linea) {
         ItemSold itemSold = super.lineaTicketToItemSold(linea);
 
+        if (linea != null && itemSold != null) {
+            BigDecimal importeAhorrado = linea.getImporteTotalPromociones();
+            ItemSold discountApplied = itemSold.getDiscountApplied();
+
+            if (discountApplied != null) {
+                if (importeAhorrado == null) {
+                    importeAhorrado = BigDecimal.ZERO;
+                }
+
+                discountApplied.setFieldIntValue(ItemSold.DiscountAmount, importeAhorrado);
+            }
+        }
+
         if (linea != null && itemSold != null && ticketManager instanceof AmetllerScoTicketManager) {
             AmetllerScoTicketManager ametllerScoTicketManager = (AmetllerScoTicketManager) ticketManager;
             if (ametllerScoTicketManager.hasDescuento25Aplicado(linea)) {


### PR DESCRIPTION
## Summary
- populate the discount amount on the custom Ametller item messages so line updates are detected
- keep existing 25% discount handling intact while allowing loyalty promos applied after scanning to refresh the UI

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df9bf105a4832ba3865acecd84dceb