### PR TITLE
Avoid duplicate NCR messages after loyalty promotions

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
@@ -13,6 +13,7 @@ import com.comerzzia.ametller.pos.ncr.ticket.AmetllerScoTicketManager;
 import com.comerzzia.pos.ncr.actions.sale.ItemsManager;
 import com.comerzzia.pos.ncr.messages.ItemException;
 import com.comerzzia.pos.ncr.messages.ItemSold;
+import com.comerzzia.pos.services.ticket.TicketVentaAbono;
 import com.comerzzia.pos.services.ticket.lineas.LineaTicket;
 import com.comerzzia.pos.util.bigdecimal.BigDecimalUtil;
 import com.comerzzia.pos.util.i18n.I18N;
@@ -90,6 +91,26 @@ public class AmetllerItemsManager extends ItemsManager {
 
         ncrController.sendMessage(itemSold);
         sendTotals();
+    }
+
+
+    @Override
+    public void newItem(final LineaTicket newLine) {
+        if (newLine == null) {
+            return;
+        }
+
+        if (ticketManager != null && ticketManager.getTicket() != null) {
+            ticketManager.getSesion().getSesionPromociones()
+                    .aplicarPromociones((TicketVentaAbono) ticketManager.getTicket());
+            ticketManager.getTicket().getTotales().recalcular();
+        }
+
+        ItemSold response = lineaTicketToItemSold(newLine);
+
+        sendItemSold(response);
+
+        linesCache.put(newLine.getIdLinea(), response);
     }
 
 


### PR DESCRIPTION
## Summary
- Reapply promotions before emitting new item NCR messages so promotions are reflected immediately
- Update the cached item data after recalculation to avoid duplicate ItemSold and Totals emissions

## Testing
- mvn -q -DskipTests package *(fails: dependency repository blocked by environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a91138ec832bb27fce462bc7acb4