### PR TITLE
Prevent gift card provisional charges from persisting after voids

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Primary;
@@ -13,6 +14,7 @@ import com.comerzzia.ametller.pos.ncr.ticket.AmetllerScoTicketManager;
 import com.comerzzia.pos.ncr.actions.sale.ItemsManager;
 import com.comerzzia.pos.ncr.messages.ItemException;
 import com.comerzzia.pos.ncr.messages.ItemSold;
+import com.comerzzia.pos.ncr.messages.VoidTransaction;
 import com.comerzzia.pos.services.ticket.TicketVentaAbono;
 import com.comerzzia.pos.services.ticket.lineas.LineaTicket;
 import com.comerzzia.pos.util.bigdecimal.BigDecimalUtil;
@@ -25,6 +27,10 @@ import com.comerzzia.pos.util.i18n.I18N;
 public class AmetllerItemsManager extends ItemsManager {
 
     private static final String DESCUENTO_25_DESCRIPTION = "Descuento del 25% aplicado";
+
+    @Autowired
+    @Lazy
+    private AmetllerPayManager ametllerPayManager;
 
     @Override
     protected ItemSold lineaTicketToItemSold(LineaTicket linea) {
@@ -111,6 +117,24 @@ public class AmetllerItemsManager extends ItemsManager {
         sendItemSold(response);
 
         linesCache.put(newLine.getIdLinea(), response);
+    }
+
+    @Override
+    public void newTicket() {
+        super.newTicket();
+
+        if (ametllerPayManager != null) {
+            ametllerPayManager.onTransactionStarted();
+        }
+    }
+
+    @Override
+    public void deleteAllItems(VoidTransaction message) {
+        if (ametllerPayManager != null) {
+            ametllerPayManager.onTransactionVoided();
+        }
+
+        super.deleteAllItems(message);
     }
 
 

--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerPayManager.java
@@ -49,10 +49,8 @@ import com.comerzzia.pos.ncr.messages.DataNeeded;
 import com.comerzzia.pos.ncr.messages.DataNeededReply;
 import com.comerzzia.pos.ncr.messages.EndTransaction;
 import com.comerzzia.pos.ncr.messages.Receipt;
-import com.comerzzia.pos.ncr.messages.StartTransaction;
 import com.comerzzia.pos.ncr.messages.Tender;
 import com.comerzzia.pos.ncr.messages.TenderException;
-import com.comerzzia.pos.ncr.messages.VoidTransaction;
 import com.comerzzia.pos.persistence.giftcard.GiftCardBean;
 import com.comerzzia.pos.persistence.mediosPagos.MedioPagoBean;
 import com.comerzzia.pos.services.core.sesion.Sesion;
@@ -110,18 +108,10 @@ public class AmetllerPayManager extends PayManager {
         public void init() {
                 super.init();
                 ncrController.registerActionManager(DataNeededReply.class, this);
-                ncrController.registerActionManager(StartTransaction.class, this);
-                ncrController.registerActionManager(VoidTransaction.class, this);
         }
 
-	@Override
+        @Override
         public void processMessage(BasicNCRMessage message) {
-                if (message instanceof VoidTransaction) {
-                        handleTransactionVoid();
-                }
-                else if (message instanceof StartTransaction) {
-                        clearPendingGiftCardPayments();
-                }
                 if (message instanceof DataNeededReply) {
                         DataNeededReply reply = (DataNeededReply) message;
                         if (handleDescuento25DataNeededReply(reply)) {
@@ -1096,7 +1086,7 @@ public class AmetllerPayManager extends PayManager {
                 }
         }
 
-        private void handleTransactionVoid() {
+        public void onTransactionVoided() {
                 if (pendingGiftCardPayments.isEmpty()) {
                         return;
                 }
@@ -1108,6 +1098,10 @@ public class AmetllerPayManager extends PayManager {
                         cancelGiftCardMovement(uid, context);
                 }
 
+                clearPendingGiftCardPayments();
+        }
+
+        public void onTransactionStarted() {
                 clearPendingGiftCardPayments();
         }
 


### PR DESCRIPTION
## Summary
- track pending gift card payments so provisional movements can be voided when the SCO cancels a transaction
- cancel any outstanding provisional gift card movements on void and clear the cache when a new transaction starts or finishes

## Testing
- `mvn -q -DskipTests package` *(fails: blocked mirror for internal Maven repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68e4e929f628832bab747506675f8282