### PR TITLE
Ensure bagging prompt after promotional refresh

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
@@ -25,6 +25,7 @@ import com.comerzzia.pos.util.i18n.I18N;
 public class AmetllerItemsManager extends ItemsManager {
 
     private static final String DESCUENTO_25_DESCRIPTION = "Descuento del 25% aplicado";
+    private boolean suppressTotalsOnUpdate;
 
     @Override
     protected ItemSold lineaTicketToItemSold(LineaTicket linea) {
@@ -144,10 +145,30 @@ public class AmetllerItemsManager extends ItemsManager {
                     || !StringUtils.equals(cachedExtendedPrice, refreshedExtendedPrice)
                     || !StringUtils.equals(cachedDescription, refreshedDescription)) {
                 ncrController.sendMessage(refreshedItem);
-                sendTotals();
+
+                if (!suppressTotalsOnUpdate) {
+                    sendTotals();
+                }
+
                 linesCache.put(ticketLine.getIdLinea(), refreshedItem);
             }
         }
+    }
+
+    @Override
+    public void newItemAndUpdateAllItems(final LineaTicket newLine) {
+        if (newLine == null) {
+            return;
+        }
+
+        suppressTotalsOnUpdate = true;
+        try {
+            updateItems();
+        } finally {
+            suppressTotalsOnUpdate = false;
+        }
+
+        newItem(newLine);
     }
     
 	@Override


### PR DESCRIPTION
## Summary
- add a guard flag to skip totals when refreshing cached lines before a new scan
- run cached-line updates before emitting the new item so NCR receives the last ItemSold for the current scan

## Testing
- `mvn -q test` *(fails: missing remote dependencies blocked by maven-default-http-blocker)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ea7ae5c4832badee4d0a9dc69242