### PR TITLE
Avoid resending ItemSold when promotions adjust prices

### DIFF
--- a/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
+++ b/src/main/java/com/comerzzia/ametller/pos/ncr/actions/sale/AmetllerItemsManager.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import com.comerzzia.ametller.pos.ncr.ticket.AmetllerScoTicketManager;
 import com.comerzzia.pos.ncr.actions.sale.ItemsManager;
 import com.comerzzia.pos.ncr.messages.ItemException;
+import com.comerzzia.pos.ncr.messages.ItemPriceChanged;
 import com.comerzzia.pos.ncr.messages.ItemSold;
 import com.comerzzia.pos.ncr.messages.VoidTransaction;
 import com.comerzzia.pos.services.ticket.TicketVentaAbono;
@@ -167,8 +168,26 @@ public class AmetllerItemsManager extends ItemsManager {
             if (!StringUtils.equals(cachedPrice, refreshedPrice)
                     || !StringUtils.equals(cachedExtendedPrice, refreshedExtendedPrice)
                     || !StringUtils.equals(cachedDescription, refreshedDescription)) {
-                ncrController.sendMessage(refreshedItem);
-                sendTotals();
+                ItemPriceChanged priceChanged = new ItemPriceChanged();
+                priceChanged.setFieldValue(ItemPriceChanged.UPC, refreshedItem.getFieldValue(ItemSold.UPC));
+                priceChanged.setFieldValue(ItemPriceChanged.ItemNumber, refreshedItem.getFieldValue(ItemSold.ItemNumber));
+
+                BigDecimal precioConDto = ticketLine.getPrecioTotalConDto();
+                if (precioConDto != null) {
+                    priceChanged.setFieldIntValue(ItemPriceChanged.NewPrice, precioConDto);
+                }
+
+                BigDecimal importeConDto = ticketLine.getImporteTotalConDto();
+                if (importeConDto != null) {
+                    priceChanged.setFieldIntValue(ItemPriceChanged.ExtendedPrice, importeConDto);
+                }
+
+                BigDecimal cantidad = ticketLine.getCantidad();
+                if (cantidad != null) {
+                    priceChanged.setFieldIntValue(ItemPriceChanged.Quantity, cantidad);
+                }
+
+                ncrController.sendMessage(priceChanged);
                 linesCache.put(ticketLine.getIdLinea(), refreshedItem);
             }
         }


### PR DESCRIPTION
## Summary
- stop resending ItemSold messages when promotion re-calculations adjust a line
- emit an ItemPriceChanged message instead so the SCO keeps the same item number per line
- update the cached line data after sending the price change notification

## Testing
- `mvn -q -DskipTests package` *(fails: dependency artifacts are hosted on blocked repositories in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e60d930030832b86c6e8873b292beb